### PR TITLE
Support other english language parkrun websites

### DIFF
--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -17,7 +17,16 @@
 
   "content_scripts": [
     {
-      "matches": ["*://www.parkrun.org.uk/results/athleteeventresultshistory/*"],
+      "matches": [
+          "*://www.parkrun.org.uk/results/athleteeventresultshistory/*",
+          "*://www.parkrun.com.au/results/athleteeventresultshistory/*",
+          "*://www.parkrun.co.nz/results/athleteeventresultshistory/*",
+          "*://www.parkrun.ca/results/athleteeventresultshistory/*",
+          "*://www.parkrun.ie/results/athleteeventresultshistory/*",
+          "*://www.parkrun.co.za/results/athleteeventresultshistory/*",
+          "*://www.parkrun.us/results/athleteeventresultshistory/*",
+          "*://www.parkrun.sg/results/athleteeventresultshistory/*"
+      ],
       "js": [
           "js/lib/third-party/jquery-3.3.1.js",
           "js/lib/challenges.js",
@@ -27,7 +36,16 @@
       "run_at": "document_end"
   },
   {
-    "matches": ["*://www.parkrun.org.uk/results/athleteresultshistory/*"],
+    "matches": [
+        "*://www.parkrun.org.uk/results/athleteresultshistory/*",
+        "*://www.parkrun.com.au/results/athleteresultshistory/*",
+        "*://www.parkrun.co.nz/results/athleteresultshistory/*",
+        "*://www.parkrun.ca/results/athleteresultshistory/*",
+        "*://www.parkrun.ie/results/athleteresultshistory/*",
+        "*://www.parkrun.co.za/results/athleteresultshistory/*",
+        "*://www.parkrun.us/results/athleteresultshistory/*",
+        "*://www.parkrun.sg/results/athleteresultshistory/*"
+    ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",
         "js/content-scripts/content-script-athleteresultshistory.js"

--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -53,7 +53,16 @@
     "run_at": "document_end"
   },
   {
-    "matches": ["*://www.parkrun.org.uk/*/results/athletehistory/*"],
+    "matches": [
+        "*://www.parkrun.org.uk/*/results/athletehistory/*",
+        "*://www.parkrun.com.au/*/results/athletehistory/*",
+        "*://www.parkrun.co.nz/*/results/athletehistory/*",
+        "*://www.parkrun.ca/*/results/athletehistory/*",
+        "*://www.parkrun.ie/*/results/athletehistory/*",
+        "*://www.parkrun.co.za/*/results/athletehistory/*",
+        "*://www.parkrun.us/*/results/athletehistory/*",
+        "*://www.parkrun.sg/*/results/athletehistory/*"
+    ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",
         "js/content-scripts/content-script-athleteeventhistory.js"


### PR DESCRIPTION
  - For #9 
  - Adds:
    - www.parkrun.org.uk
    - www.parkrun.com.au
    - www.parkrun.co.nz
    - www.parkrun.ca
    - www.parkrun.ie
    - www.parkrun.co.za
    - www.parkrun.us
    - www.parkrun.sg