### PR TITLE
Support other languages

### DIFF
--- a/browser-extensions/chrome/css/styles.css
+++ b/browser-extensions/chrome/css/styles.css
@@ -1,0 +1,4 @@
+
+table.simple_table td {
+    border: 1px solid black;
+}

--- a/browser-extensions/chrome/html/help.html
+++ b/browser-extensions/chrome/html/help.html
@@ -23,7 +23,7 @@
     provided by parkrun.
 </p>
 <p>
-    <b>Please note:</b> This extension currently only works on the following
+    <b>Please note:</b> This extension works fully on the following
     English language parkrun websites:
     <ul>
         <li>www.parkrun.org.uk</li>
@@ -36,8 +36,21 @@
         <li>www.parkrun.sg</li>
     </ul>
 
-    When we have time to work out how to handle other languages we will see if we
-    can get it to work across all the parkrun sites.
+    Additionally, the following websites have basic support, including running
+    badges and progress, but with limited volunteer badge supported based on our
+    patchy translations:
+    <ul>
+        <li>www.parkrun.pl</li>
+        <li>www.parkrun.it</li>
+        <li>www.parkrun.dk</li>
+        <li>www.parkrun.se</li>
+        <li>www.parkrun.fi</li>
+        <li>www.parkrun.fr</li>
+        <li>www.parkrun.com.de</li>
+        <li>www.parkrun.no</li>
+        <li>www.parkrun.ru</li>
+    </ul>
+    Please see the translation section below to help out!
 </p>
 
 <h3>Where does the data come from?</h3>

--- a/browser-extensions/chrome/html/help.html
+++ b/browser-extensions/chrome/html/help.html
@@ -68,6 +68,17 @@
     this work.
 </p>
 
+<h3>Translations</h3>
+<p>
+    The <a href="/html/translations.html">translations page</a> shows the current
+    state of our attempt to support all the parkrun websites that are not in English.
+    In order for us to correctly award volunteer badges for these sites we need to
+    map the role name back in to English, and we have not yet found them all!
+    Please have a look at the table, and if you know anyone who has done a missing role
+    and has it listed on their athlete page in a language we haven't got yet, please
+    drop us a line via email and let us know at TeamTCMakers@gmail.com .
+</p>
+
 <h3>Feedback</h3>
 <p>
     If you have any feedback, please send it to TeamTCMakers@gmail.com
@@ -80,4 +91,7 @@
     play with their results and on their touristing travels. We found most of these
     games in the 'UK parkrun tourists' and 'parkrun statsgeek' Facebook groups,
     and have made up a few new ones.
+</p>
+<p>
+    <a href="/html/options.html">options</a> | <a href="/html/translations.html">translations</a>
 </p>

--- a/browser-extensions/chrome/html/options.html
+++ b/browser-extensions/chrome/html/options.html
@@ -34,7 +34,7 @@ Size (bytes): <span id='cached_geo_bytes'>unknown</span><br/>
 </p>
 
 <p>
-    <a href="/html/help.html">help</a>
+    <a href="/html/help.html">help</a> | <a href="/html/translations.html">translations</a>
 </p>
 
 <div id="debug"></div>

--- a/browser-extensions/chrome/html/translations.html
+++ b/browser-extensions/chrome/html/translations.html
@@ -7,22 +7,16 @@
 <body>
 
 <h3>Translations</h3>
-<p>
-The following table indicates the current state of the translations that are
-available for this extension. There are serveral parts that need to be
-translated for it to be useful to parkrunners all over the world.
-</p>
-<p>
-The volunteer roles appear to be displayed on the parkrun website in the language of the
-site you are registered on, which means that although most are in English, there
-are many other languages including French, German, Polish, and Russian.
-</p>
-<p>
-If you are able to provide a missing translation for a volunteer role,
-please email us at TeamTCMakers@gmail.com and include a link to an athlete who has volunteered for that role
-in the past (and check that it is listed in that language on their athlete history page) -
-this will allow us to test the translations work when we add them in
-</p>
+
+<p>Most of the parkrun websites display your results and volunteer records in English. Some parkrun websites don't display in English. The French parkrun website, for example, displays your results and volunteer records in French.</p>
+
+<p>Running Challenges works by reading the information on your parkrun results page and then adding your badges to the top of the page. It checks what badges you have achieved by looking for certain terms on the parkrun pages, like "Barocde Scanning" which indicates that you have volunteered as a Barcode Scanner at parkrun.</p>
+
+<p>If a parkrunner registered in, say, France, all their roles seem to be displayed in French. This means that Running Challenges can't find the word "Barocde Scanning" on the page. So we have to provide a list of all the French volunteer terms (e.g. "Scan des codes-barres") so that French parkrunners get the right badges displayed on their pages. And the same for each other language.</p>
+
+<p>The following table indicates the current list of volunteer roles that we have discovered for each language on the parkrun websites. As you can see, there are several gaps in the table because we couldn't find examples of all the volunteer roles on all of the non-English parkrun websites.</p>
+    
+<p>If you know what the missing volunteer roles are (the exact term used by parkrun in that language), please email us at TeamTCMakers@gmail.com. If you can, please include a link to an athlete who has volunteered for that role and has it displayed in that language on their athlete page. This means that we can test that they get the right badges when we've updated the table.</p>
 
 <h4>Volunteer Roles</h4>
 <div id="volunteer_roles"></div>

--- a/browser-extensions/chrome/html/translations.html
+++ b/browser-extensions/chrome/html/translations.html
@@ -19,7 +19,7 @@ are many other languages including French, German, Polish, and Russian.
 </p>
 <p>
 If you are able to provide a missing translation for a volunteer role,
-please email us and include a link to an athlete who has volunteered for that role
+please email us at TeamTCMakers@gmail.com and include a link to an athlete who has volunteered for that role
 in the past (and check that it is listed in that language on their athlete history page) -
 this will allow us to test the translations work when we add them in
 </p>

--- a/browser-extensions/chrome/html/translations.html
+++ b/browser-extensions/chrome/html/translations.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Running Challenges Translations</title>
+    <link rel="stylesheet" href="/css/styles.css">
+</head>
+<body>
+
+<h3>Translations</h3>
+<p>
+The following table indicates the current state of the translations that are
+available for this extension. There are serveral parts that need to be
+translated for it to be useful to parkrunners all over the world.
+</p>
+<p>
+The volunteer roles appear to be displayed on the parkrun website in the language of the
+site you are registered on, which means that although most are in English, there
+are many other languages including French, German, Polish, and Russian.
+</p>
+<p>
+If you are able to provide a missing translation for a volunteer role,
+please email us and include a link to an athlete who has volunteered for that role
+in the past (and check that it is listed in that language on their athlete history page) -
+this will allow us to test the translations work when we add them in
+</p>
+
+<h4>Volunteer Roles</h4>
+<div id="volunteer_roles"></div>
+
+<p>
+    <a href="/html/help.html">help</a> | <a href="/html/options.html">options</a>
+</p>
+
+<script src="/js/lib/third-party/jquery-3.3.1.js"></script>
+<script src="/js/lib/i18n.js"></script>
+<script src="/js/translations.js"></script>
+</body>
+</html>

--- a/browser-extensions/chrome/js/background.js
+++ b/browser-extensions/chrome/js/background.js
@@ -13,7 +13,7 @@ chrome.browserAction.onClicked.addListener(function(tab) {
         } else {
             var results_url = "http://www.parkrun.org.uk/results/athleteeventresultshistory/?athleteNumber="+items.athlete_number+"&eventNumber=0"
             if ("local_url" in items.home_parkrun_info) {
-                results_url = items.home_parkrun_info.local_url+"/results/athleteeventresultshistory/?athleteNumber="+items.athlete_number+"&eventNumber=0"
+                results_url = items.home_parkrun_info.local_url+"/"+get_localised_value("url_athleteeventresultshistory", items.home_parkrun_info.local_url)+"?athleteNumber="+items.athlete_number+"&eventNumber=0"
             }
             chrome.tabs.create({ url: results_url });
         }

--- a/browser-extensions/chrome/js/content-scripts/content-script-athleteeventhistory.js
+++ b/browser-extensions/chrome/js/content-scripts/content-script-athleteeventhistory.js
@@ -6,7 +6,7 @@ function get_athlete_id() {
     // Find the Athlete ID by looking on the page for the link which contains the
     // text "View stats for all parkruns by this athlete" to get '<a href="/athleteresultshistory?athleteNumber=1386351"></a>
     var athlete_id = null
-    $("a:contains('View stats for all parkruns by this athlete')").each(function (i) {
+    $("a:contains('"+get_localised_value("link_view_stats_for_all_parkruns2")+"')").each(function (i) {
         athlete_id = $(this).attr('href').split("=")[1]
     })
 
@@ -16,20 +16,20 @@ function get_athlete_id() {
 
 var athlete_id = get_athlete_id()
 if (athlete_id != null) {
-    url = location.protocol + '//' + location.host + '/results/athleteeventresultshistory/?athleteNumber='+athlete_id+'&eventNumber=0'
+    url = location.protocol + '//' + location.host + "/" + get_localised_value('url_athleteeventresultshistory')+'?athleteNumber='+athlete_id+'&eventNumber=0'
 
     if (url != null) {
         var challenge_link = $("<a/>").attr("href", url)
 
         var icon =  $('<img/>')
         icon.attr('src', chrome.extension.getURL("/images/logo/logo-128x128.png"))
-        icon.attr('alt', "Running Challenges")
-        icon.attr('title', "Running Challenges")
+        icon.attr('alt', get_localised_value("text_running_challenges"))
+        icon.attr('title', get_localised_value("text_running_challenges"))
         icon.attr('height', 24)
         icon.attr('width', 24)
 
         challenge_link.append(icon)
-        challenge_link.append($("<span/>").text("See Challenge Progress"))
+        challenge_link.append($("<span/>").text(get_localised_value("text_see_challenge_progress")))
         get_challenge_link_location().after($('<div/>').append($('<p/>').append(challenge_link)))
     }
 }

--- a/browser-extensions/chrome/js/content-scripts/content-script-athleteeventhistory.js
+++ b/browser-extensions/chrome/js/content-scripts/content-script-athleteeventhistory.js
@@ -6,12 +6,10 @@ function get_athlete_id() {
     // Find the Athlete ID by looking on the page for the link which contains the
     // text "View stats for all parkruns by this athlete" to get '<a href="/athleteresultshistory?athleteNumber=1386351"></a>
     var athlete_id = null
-    $("a:contains('"+get_localised_value("link_view_stats_for_all_parkruns2")+"')").each(function (i) {
+    $("a:contains('"+get_localised_value("link_view_stats_for_all_parkruns_athleteeventhistory")+"')").each(function (i) {
         athlete_id = $(this).attr('href').split("=")[1]
     })
-
     return athlete_id
-
 }
 
 var athlete_id = get_athlete_id()

--- a/browser-extensions/chrome/js/content-scripts/content-script-athleteeventresultshistory.js
+++ b/browser-extensions/chrome/js/content-scripts/content-script-athleteeventresultshistory.js
@@ -121,7 +121,7 @@ function get_badge_location() {
 
 // Generate the table structure, and add it to the page
 var challenges_table = generate_challenge_table()
-get_table('results', 'All Results').before(challenges_table)
+get_table('results', get_localised_value('table_all_results')).before(challenges_table)
 
 var badges_div = generate_challenge_badges_element()
 get_badge_location().after(badges_div)
@@ -134,7 +134,7 @@ var badges = []
 
 parkruns_completed = []
 
-get_table("results", "All Results").each(function(results_table) {
+get_table("results", get_localised_value('table_all_results')).each(function(results_table) {
     // Gather the data for this table
 
     // Find all the table body rows
@@ -220,7 +220,7 @@ function get_athlete_id() {
     // Find the Athlete ID by looking on the page for the link which contains the
     // text "View stats for all parkruns by this athlete" to get '<a href="/athleteresultshistory?athleteNumber=1386351"></a>
     var athlete_id = null
-    $("a:contains('View stats for all parkruns by this athlete')").each(function (i) {
+    $("a:contains('"+get_localised_value('link_view_stats_for_all_parkruns')+"')").each(function (i) {
         athlete_id = $(this).attr('href').split("=")[1]
     })
 
@@ -236,6 +236,11 @@ function get_volunteer_data() {
     if (athlete_id != null) {
         // console.log("Fetching volunteer data")
         $.ajax({
+             // If we translate this URL into the local one, not only do we have to
+             // parse the page separately (no big deal), but we need to add every
+             // domain into our CSP, which is a bit annoying, but would maybe
+             // turn out to be more efficient for the user in a country far away
+             // from the UK (depending on where parkrun host these servers)
              url: "https://www.parkrun.org.uk/results/athleteresultshistory/?athleteNumber="+athlete_id,
              dataType: 'html',
              success: function (result) {

--- a/browser-extensions/chrome/js/content-scripts/content-script-athleteeventresultshistory.js
+++ b/browser-extensions/chrome/js/content-scripts/content-script-athleteeventresultshistory.js
@@ -260,10 +260,13 @@ function get_volunteer_data() {
                              volunteer_role = table_cells[1].innerText
                              volunteer_role_quantity = table_cells[2].innerText
 
-                             if (!(volunteer_role in completed_volunteer_roles)) {
-                                 completed_volunteer_roles[volunteer_role] = 0
+                             // Try and translate from whatever language it is in
+                             normalised_volunteer_role = get_normalised_volunteer_role(volunteer_role)
+
+                             if (!(normalised_volunteer_role in completed_volunteer_roles)) {
+                                 completed_volunteer_roles[normalised_volunteer_role] = 0
                              }
-                             completed_volunteer_roles[volunteer_role] += parseInt(volunteer_role_quantity)
+                             completed_volunteer_roles[normalised_volunteer_role] += parseInt(volunteer_role_quantity)
                          })
                          // console.log(completed_volunteer_roles)
                      })

--- a/browser-extensions/chrome/js/content-scripts/content-script-athleteresultshistory.js
+++ b/browser-extensions/chrome/js/content-scripts/content-script-athleteresultshistory.js
@@ -23,12 +23,12 @@ if (url != null) {
 
     var icon =  $('<img/>')
     icon.attr('src', chrome.extension.getURL("/images/logo/logo-128x128.png"))
-    icon.attr('alt', "Running Challenges")
-    icon.attr('title', "Running Challenges")
+    icon.attr('alt', get_localised_value("text_running_challenges"))
+    icon.attr('title', get_localised_value("text_running_challenges"))
     icon.attr('height', 24)
     icon.attr('width', 24)
 
     challenge_link.append(icon)
-    challenge_link.append($("<span/>").text("See Challenge Progress"))
+    challenge_link.append($("<span/>").text(get_localised_value("text_see_challenge_progress")))
     get_challenge_link_location().after($('<div/>').append($('<p/>').append(challenge_link)))
 }

--- a/browser-extensions/chrome/js/content-scripts/content-script-athleteresultshistory.js
+++ b/browser-extensions/chrome/js/content-scripts/content-script-athleteresultshistory.js
@@ -2,6 +2,17 @@ function get_challenge_link_location() {
     return $("div[id=content]").find("p:first")
 }
 
+function get_athlete_id() {
+    // Find the Athlete ID by looking on the page for the link which contains the
+    // text "View stats for all parkruns by this athlete" to get '<a href="/athleteresultshistory?athleteNumber=1386351"></a>
+    var athlete_id = null
+    $("a:contains('"+get_localised_value("link_all")+"'):first").each(function (i) {
+        console.log($(this).attr('href'))
+        athlete_id = $(this).attr('href').split("=")[1]
+    })
+    return athlete_id
+}
+
 function get_athleteeventresultshistory_url() {
     var returned_url = null
     $('a').each(function (index) {
@@ -16,19 +27,22 @@ function get_athleteeventresultshistory_url() {
     return returned_url
 }
 
+var athlete_id = get_athlete_id()
+if (athlete_id != null) {
+    url = location.protocol + '//' + location.host + "/" + get_localised_value('url_athleteeventresultshistory')+'?athleteNumber='+athlete_id+'&eventNumber=0'
 
-var url = get_athleteeventresultshistory_url();
-if (url != null) {
-    var challenge_link = $("<a/>").attr("href", url)
+    if (url != null) {
+        var challenge_link = $("<a/>").attr("href", url)
 
-    var icon =  $('<img/>')
-    icon.attr('src', chrome.extension.getURL("/images/logo/logo-128x128.png"))
-    icon.attr('alt', get_localised_value("text_running_challenges"))
-    icon.attr('title', get_localised_value("text_running_challenges"))
-    icon.attr('height', 24)
-    icon.attr('width', 24)
+        var icon =  $('<img/>')
+        icon.attr('src', chrome.extension.getURL("/images/logo/logo-128x128.png"))
+        icon.attr('alt', get_localised_value("text_running_challenges"))
+        icon.attr('title', get_localised_value("text_running_challenges"))
+        icon.attr('height', 24)
+        icon.attr('width', 24)
 
-    challenge_link.append(icon)
-    challenge_link.append($("<span/>").text(get_localised_value("text_see_challenge_progress")))
-    get_challenge_link_location().after($('<div/>').append($('<p/>').append(challenge_link)))
+        challenge_link.append(icon)
+        challenge_link.append($("<span/>").text(get_localised_value("text_see_challenge_progress")))
+        get_challenge_link_location().after($('<div/>').append($('<p/>').append(challenge_link)))
+    }
 }

--- a/browser-extensions/chrome/js/lib/challenges.js
+++ b/browser-extensions/chrome/js/lib/challenges.js
@@ -527,9 +527,11 @@ function challenge_single_parkrun_count(results, params) {
             }
         })
     } else {
-        // If it isn't complete, give the biggest one so far as detail info
-        max_parkrun.info = max_parkrun.count
-        o.subparts_detail.push(max_parkrun)
+        if (max_parkrun !== null) {
+            // If it isn't complete, give the biggest one so far as detail info
+            max_parkrun.info = max_parkrun.count
+            o.subparts_detail.push(max_parkrun)
+        }
     }
 
 

--- a/browser-extensions/chrome/js/lib/i18n.js
+++ b/browser-extensions/chrome/js/lib/i18n.js
@@ -2,6 +2,36 @@
 // still work across all of the parkrun sites
 // Although most of the content is still in English, such as the parkrun names
 
+// Volunteer roles are in the language of the person who signed up,
+// so a Russian parkrunner who has done volunteering will have all their roles
+// listed in Russian even if they are fetched from the .org.uk website
+
+// Known Roles:
+// "Equipment Storage and Delivery"
+// "Communications Person"
+// "Volunteer Co-ordinator"
+// "Pre-event Setup"
+// "First Timers Briefing"
+// "Sign Language Support"
+// "Marshal"
+// "Tail Walker"
+// "Run Director"
+// "Lead Bike"
+// "Pacer (5k only)"
+// "VI Guide"
+// "Photographer"
+// "Timekeeper"
+// "Backup Timer"
+// "Funnel Manager"
+// "Finish Tokens"
+// "Finish Token Support"
+// "Barcode Scanning"
+// "Number Checker"
+// "Post-event Close Down"
+// "Results Processor"
+// "Token Sorting"
+// "Run Report Writer"
+// + Other?, Warm Up (Juniors)
 var domains = {
     // Default english language options, good for most of the domains
     "default": {
@@ -12,7 +42,34 @@ var domains = {
         "link_all": "All",
         // These variables contain text we output, so need translating by someone
         "text_see_challenge_progress": "See challenge progress",
-        "text_running_challenges": "Running Challenges"
+        "text_running_challenges": "Running Challenges",
+        // Volunteer roles are in ENGLISH
+        "text_volunteer_role_map": {
+            "Equipment Storage and Delivery": "Equipment Storage and Delivery",
+            "Communications Person": "Communications Person",
+            "Volunteer Co-ordinator": "Volunteer Co-ordinator",
+            "Pre-event Setup": "Pre-event Setup",
+            "First Timers Briefing": "First Timers Briefing",
+            "Sign Language Support": "Sign Language Support",
+            "Marshal": "Marshal",
+            "Tail Walker": "Tail Walker",
+            "Run Director": "Run Director",
+            "Lead Bike": "Lead Bike",
+            "Pacer (5k only)": "Pacer (5k only)",
+            "VI Guide": "VI Guide",
+            "Photographer": "Photographer",
+            "Timekeeper": "Timekeeper",
+            "Backup Timer": "Backup Timer",
+            "Funnel Manager": "Funnel Manager",
+            "Finish Tokens": "Finish Tokens",
+            "Finish Token Support": "Finish Token Support",
+            "Barcode Scanning": "Barcode Scanning",
+            "Number Checker": "Number Checker",
+            "Post-event Close Down": "Post-event Close Down",
+            "Results Processor": "Results Processor",
+            "Token Sorting": "Token Sorting",
+            "Run Report Writer": "Run Report Writer"
+        }
     },
     "www.parkrun.pl": {
         // Polish pages
@@ -23,6 +80,32 @@ var domains = {
         "table_all_results": "Wszystkie wyniki",
         "link_view_stats_for_all_parkruns": "Zobacz statystyki uczestnika ze wszystkich biegów parkrun",
         "link_view_stats_for_all_parkruns_athleteeventhistory": "Zobacz wyniki tego zawodnika ze wszystkich biegów",
+        "text_volunteer_role_map": {
+            "Przechowując(a)y sprzęt": "Equipment Storage and Delivery",
+            "Osoba od komunikacji": "Communications Person",
+            // "Volunteer Co-ordinator": "Volunteer Co-ordinator",
+            "Ustawiając(a)y elementy trasy": "Pre-event Setup",
+            "Instruktor nowych uczestników": "First Timers Briefing",
+            // "Sign Language Support": "Sign Language Support",
+            "Ubezpieczając(a)y trasę": "Marshal",
+            // "Tail Walker": "Tail Walker",
+            "Koordynator biegu": "Run Director",
+            "Rower bezpieczeństwa": "Lead Bike",
+            // "Pacer (5k only)": "Pacer (5k only)",
+            // "VI Guide": "VI Guide",
+            "Fotograf": "Photographer",
+            "Osoba mierząca czas": "Timekeeper",
+            // "Backup Timer": "Backup Timer",
+            "Koordynator tunelu mety": "Funnel Manager",
+            "Pozycje na mecie": "Finish Tokens",
+            "Asystując(a)y przy pozycjach": "Finish Token Support",
+            "Skanując(a)y uczestników": "Barcode Scanning",
+            // "Number Checker": "Number Checker",
+            "Zamykając(a)y stawkę": "Post-event Close Down",
+            "Wprowadzając(a)y wyniki": "Results Processor",
+            // "Token Sorting": "Token Sorting",
+            // "Run Report Writer": "Run Report Writer"
+        }
     },
     "www.parkrun.it": {
         // Italian pages
@@ -32,6 +115,33 @@ var domains = {
         "table_all_results": "Tutti i risultati",
         "link_view_stats_for_all_parkruns": "Visualizza statistiche per tutti i parkruns di questo atleta",
         "link_view_stats_for_all_parkruns_athleteeventhistory": "Visualizza statistiche per tutti i parkruns di questo atleta",
+        "text_volunteer_role_map": {
+            // "Equipment Storage and Delivery": "Equipment Storage and Delivery",
+            // "Communications Person": "Communications Person",
+            // "Volunteer Co-ordinator": "Volunteer Co-ordinator",
+            "Preparazione evento": "Pre-event Setup",
+            // "First Timers Briefing": "First Timers Briefing",
+            // "Sign Language Support": "Sign Language Support",
+            "Marshal": "Marshal",
+            "Camminatore di coda": "Tail Walker",
+            "Direttore di Corsa": "Run Director",
+            "Ciclista apripista": "Lead Bike",
+            "Pacer": "Pacer (5k only)",
+            // "VI Guide": "VI Guide",
+            "Fotografo": "Photographer",
+            "Cronometrista": "Timekeeper",
+            "Backup Timer": "Backup Timer",
+            // "Funnel Manager": "Funnel Manager",
+            "Addetto token": "Finish Tokens",
+            // "Finish Token Support": "Finish Token Support",
+            "Addetto scanner": "Barcode Scanning",
+            // "Number Checker": "Number Checker",
+            // "Post-event Close Down": "Post-event Close Down",
+            "Elaboratore risultati": "Results Processor",
+            // "Token Sorting": "Token Sorting",
+            // "Run Report Writer": "Run Report Writer"
+        }
+
     },
     "www.parkrun.dk": {
         // Danish pages
@@ -41,6 +151,32 @@ var domains = {
         "table_all_results": "Alle resultater",
         "link_view_stats_for_all_parkruns": "Se tal for alle parkruns løbet af denne løber",
         "link_view_stats_for_all_parkruns_athleteeventhistory": "Se tal for alle parkruns løbet af denne løber",
+        "text_volunteer_role_map": {
+            "Udstyr – opbevaring og levering": "Equipment Storage and Delivery",
+            // "Communications Person": "Communications Person",
+            "Hjælperkoordinering": "Volunteer Co-ordinator",
+            "Skiltning": "Pre-event Setup",
+            // "First Timers Briefing": "First Timers Briefing",
+            // "Sign Language Support": "Sign Language Support",
+            // "Marshal": "Marshal",
+            "Gående bagtrop": "Tail Walker",
+            "Løbsleder": "Run Director",
+            // "Lead Bike": "Lead Bike",
+            // "Pacer (5k only)": "Pacer (5k only)",
+            // "VI Guide": "VI Guide",
+            "Fotograf": "Photographer",
+            "Tidtager": "Timekeeper",
+            // "Backup Timer": "Backup Timer",
+            // "Funnel Manager": "Funnel Manager",
+            "Talonuddeling	": "Finish Tokens",
+            // "Finish Token Support": "Finish Token Support",
+            "Talonkontrol": "Barcode Scanning",
+            // "Number Checker": "Number Checker",
+            // "Post-event Close Down": "Post-event Close Down",
+            "Resultatregistrering": "Results Processor",
+            // "Token Sorting": "Token Sorting",
+            // "Run Report Writer": "Run Report Writer"
+        }
     },
     "www.parkrun.se": {
         // Swedish pages
@@ -50,6 +186,34 @@ var domains = {
         "table_all_results": "Alla resultat",
         "link_view_stats_for_all_parkruns": "Se statistik för alla parkruns av denna löpare",
         "link_view_stats_for_all_parkruns_athleteeventhistory": "Se statistik för alla parkruns av denna löpare",
+        "text_volunteer_role_map": {
+            // Målfållaansvarig?
+            // Förcyklist?
+            // "Equipment Storage and Delivery": "Equipment Storage and Delivery",
+            // "Communications Person": "Communications Person",
+            // "Volunteer Co-ordinator": "Volunteer Co-ordinator",
+            "Ansvarig för att sätta upp banan": "Pre-event Setup",
+            // "First Timers Briefing": "First Timers Briefing",
+            // "Sign Language Support": "Sign Language Support",
+            "Funktionär": "Marshal",
+            "Sista gångare": "Tail Walker",
+            "Loppansvarig": "Run Director",
+            // "Lead Bike": "Lead Bike",
+            // "Pacer (5k only)": "Pacer (5k only)",
+            // "VI Guide": "VI Guide",
+            "Fotograf": "Photographer",
+            "Tidtagare": "Timekeeper",
+            // "Backup Timer": "Backup Timer",
+            // "Funnel Manager": "Funnel Manager",
+            "Pollettutdelare": "Finish Tokens",
+            "Pollettutdelare assistent": "Finish Token Support",
+            "Streckkod scanning": "Barcode Scanning",
+            // "Number Checker": "Number Checker",
+            // "Post-event Close Down": "Post-event Close Down",
+            // "Results Processor": "Results Processor",
+            // "Token Sorting": "Token Sorting",
+            "Journalist": "Run Report Writer"
+        }
     },
     "www.parkrun.fi": {
         // Finnish pages
@@ -62,11 +226,39 @@ var domains = {
         // French pages
         // http://www.parkrun.fr/boisdeboulogne/results/athletehistory/?athleteNumber=422364
         // http://www.parkrun.fr/results/athleteresultshistory/?athleteNumber=422364
-        // http://www.parkrun.se/results/athleteeventresultshistory/?athleteNumber=3899897&eventNumber=0
+        // http://www.parkrun.fr/results/athleteeventresultshistory/?athleteNumber=2769739&eventNumber=0
         "table_all_results": "Toutes les participations",
         "link_view_stats_for_all_parkruns": "Consulter les stats de cet athlète tous parkruns confondus",
         "link_view_stats_for_all_parkruns_athleteeventhistory": "Consulter les stats de cet athlète tous parkruns confondus",
-        // Volunteers are translated here too
+        // Volunteer roles are in FRENCH (A582667)
+        "text_volunteer_role_map": {
+            // "Gestion SAS": "?",
+
+            // "Equipment Storage and Delivery",
+            // "Communications Person",
+            // "Volunteer Co-ordinator",
+            "Balisage du parcours": "Pre-event Setup",
+            // "First Timers Briefing",
+            // "Sign Language Support",
+            "Aiguilleur": "Marshal",
+            "Fermeur marcheur": "Tail Walker",
+            "Responsable de footing": "Run Director",
+            // "Lead Bike",
+            // "Pacer (5k only)",
+            // "VI Guide",
+            "Photographe": "Photographer",
+            "Responsable chrono": "Timekeeper",
+            // "Backup Timer",
+            // "Funnel Manager",
+            "Distribution des jetons": "Finish Tokens",
+            "Assistant distribution des jetons": "Finish Token Support",
+            "Scan des codes-barres": "Barcode Scanning",
+            // "Number Checker",
+            "Débalisage du parcours": "Post-event Close Down",
+            "Mise en ligne des participations": "Results Processor",
+            // "Token Sorting",
+            "Rédacteur du compte-rendu": "Run Report Writer"
+        }
     },
     "www.parkrun.com.de": {
         // German pages
@@ -76,11 +268,41 @@ var domains = {
         "table_all_results": "Alle Ergebnisse",
         "link_view_stats_for_all_parkruns": "Statistiken für alle Läufe dieses Athleten ansehen",
         "link_view_stats_for_all_parkruns_athleteeventhistory": "Statistiken für alle Läufe dieses Athleten ansehen",
+        // Volunteer roles are in GERMAN (A4029732)
+        "text_volunteer_role_map": {
+            "Ausrüstung Lagerung und Lieferung": "Equipment Storage and Delivery",
+            // "Communications Person": "Communications Person",
+            "Helfer Koordinator": "Volunteer Co-ordinator",
+            "Veranstaltung Aufbau": "Pre-event Setup",
+            "Einweiser für Erstläufer": "First Timers Briefing",
+            // "Sign Language Support": "Sign Language Support",
+            "Streckenposten": "Marshal",
+            // "Tail Walker": "Tail Walker",
+            "Veranstaltungsleiter": "Run Director",
+            // "Lead Bike": "Lead Bike",
+            // "Pacer (5k only)": "Pacer (5k only)",
+            // "VI Guide": "VI Guide",
+            // "Photographer": "Photographer",
+            "Zeitnehmer": "Timekeeper",
+            // "Backup Timer": "Backup Timer",
+            // "Funnel Manager": "Funnel Manager",
+            "Platzierungskarten Ausgabe": "Finish Tokens",
+            // "Finish Token Support": "Finish Token Support",
+            "Barcode Einleser": "Barcode Scanning",
+            // "Number Checker": "Number Checker",
+            // "Post-event Close Down": "Post-event Close Down",
+            "Ergebnis Auswerter": "Results Processor",
+            // "Token Sorting": "Token Sorting",
+            "Berichterstattung": "Run Report Writer"
+        }
     },
     "www.parkrun.no": {
         // Norweigen pages
-
+        // http://www.parkrun.no/toyen/results/athletehistory/?athleteNumber=4370177
+        // http://www.parkrun.no/results/athleteresultshistory/?athleteNumber=4370177
+        // http://www.parkrun.no/results/athleteeventresultshistory/?athleteNumber=4370177&eventNumber=0
         // It's all in English
+        // Volunteer roles are in ENGLISH
     },
     "www.parkrun.ru": {
         // Russian pages
@@ -88,9 +310,35 @@ var domains = {
         // http://www.parkrun.ru/results/athleteresultshistory/?athleteNumber=1551222
         // http://www.parkrun.ru/results/athleteeventresultshistory/?athleteNumber=1551222&eventNumber=0
         // Randomly partly in English
-        "link_view_stats_for_all_parkruns_athleteeventhistory": "Показать статистику этого спортсмена по всем забегам"
-        // But annoyingly, the volunteer roles have been translated in Russian,
-        // which doesn't happen on any other site
+        "link_view_stats_for_all_parkruns_athleteeventhistory": "Показать статистику этого спортсмена по всем забегам",
+        // Volunteer roles are in RUSSIAN (A1551222)
+        "text_volunteer_role_map": {
+            "Хранение и доставка оборудования": "Equipment Storage and Delivery",
+            "Связи с общественностью": "Communications Person",
+            // "Volunteer Co-ordinator"
+            "Preparation of the race": "Pre-event Setup",
+            "Инструктаж новых бегунов": "First Timers Briefing",
+            // "Sign Language Support"
+            "Маршал": "Marshal"
+            // "Tail Walker"
+            "Руководитель забега": "Run Director",
+            // "Lead Bike"
+            // "Pacer (5k only)"
+            // "VI Guide"
+            "Фотограф": "Photographer",
+            "Секундомер": "Timekeeper",
+            "Запасной секундомер": "Backup Timer",
+            // "Funnel Manager"
+            "Раздача карточек позиций": "Finish Tokens",
+            "Помощь в раздаче карточек позиций": "Finish Token Support",
+            "Сканирование штрих-кодов": "Barcode Scanning",
+            // "Number Checker"
+            "Замыкающий": "Post-event Close Down",
+            "Обработка результатов": "Results Processor",
+            "Сортировка карточек": "Token Sorting",
+            "Составление отчёта": "Run Report Writer",
+            // + Other?, Warm Up (Juniors)
+        }
     }
 }
 
@@ -109,4 +357,26 @@ function get_localised_value(param, domain=location.host) {
 function get_localised_default_value(param) {
     console.log("I18N:"+param+":"+domains.default[param])
     return domains.default[param]
+}
+
+function get_normalised_volunteer_role(role) {
+    mapped_role = null
+    $.each(domains, function(domain, mappings) {
+        if ("text_volunteer_role_map" in mappings) {
+            if (role in mappings.text_volunteer_role_map) {
+                mapped_role = mappings.text_volunteer_role_map[role]
+                // Break out of the loop
+                return false
+            }
+        }
+    })
+    if (mapped_role === null) {
+        console.log("I18N: UNKNOWN VOLUNTEER ROLE: "+role)
+        alert(role)
+    } else {
+        if (role != mapped_role) {
+            // console.log("I18N: mapped "+role+" to "+mapped_role)
+        }
+    }
+    return mapped_role
 }

--- a/browser-extensions/chrome/js/lib/i18n.js
+++ b/browser-extensions/chrome/js/lib/i18n.js
@@ -277,7 +277,7 @@ var domains = {
             "Einweiser für Erstläufer": "First Timers Briefing",
             // "Sign Language Support": "Sign Language Support",
             "Streckenposten": "Marshal",
-            // "Tail Walker": "Tail Walker",
+            "Schlussbegleitung": "Tail Walker",
             "Veranstaltungsleiter": "Run Director",
             // "Lead Bike": "Lead Bike",
             // "Pacer (5k only)": "Pacer (5k only)",
@@ -319,7 +319,7 @@ var domains = {
             "Preparation of the race": "Pre-event Setup",
             "Инструктаж новых бегунов": "First Timers Briefing",
             // "Sign Language Support"
-            "Маршал": "Marshal"
+            "Маршал": "Marshal",
             // "Tail Walker"
             "Руководитель забега": "Run Director",
             // "Lead Bike"
@@ -372,7 +372,6 @@ function get_normalised_volunteer_role(role) {
     })
     if (mapped_role === null) {
         console.log("I18N: UNKNOWN VOLUNTEER ROLE: "+role)
-        alert(role)
     } else {
         if (role != mapped_role) {
             // console.log("I18N: mapped "+role+" to "+mapped_role)

--- a/browser-extensions/chrome/js/lib/i18n.js
+++ b/browser-extensions/chrome/js/lib/i18n.js
@@ -57,6 +57,40 @@ var domains = {
         // http://www.parkrun.fi/results/athleteresultshistory/?athleteNumber=4064283
         // http://www.parkrun.fi/results/athleteeventresultshistory/?athleteNumber=4064283&eventNumber=0
         // It is all in English
+    },
+    "www.parkrun.fr": {
+        // French pages
+        // http://www.parkrun.fr/boisdeboulogne/results/athletehistory/?athleteNumber=422364
+        // http://www.parkrun.fr/results/athleteresultshistory/?athleteNumber=422364
+        // http://www.parkrun.se/results/athleteeventresultshistory/?athleteNumber=3899897&eventNumber=0
+        "table_all_results": "Toutes les participations",
+        "link_view_stats_for_all_parkruns": "Consulter les stats de cet athlète tous parkruns confondus",
+        "link_view_stats_for_all_parkruns_athleteeventhistory": "Consulter les stats de cet athlète tous parkruns confondus",
+        // Volunteers are translated here too
+    },
+    "www.parkrun.com.de": {
+        // German pages
+        // http://www.parkrun.com.de/georgengarten/results/athletehistory/?athleteNumber=4099000
+        // http://www.parkrun.com.de/results/athleteresultshistory/?athleteNumber=4099000
+        // http://www.parkrun.com.de/results/athleteeventresultshistory/?athleteNumber=4099000&eventNumber=0
+        "table_all_results": "Alle Ergebnisse",
+        "link_view_stats_for_all_parkruns": "Statistiken für alle Läufe dieses Athleten ansehen",
+        "link_view_stats_for_all_parkruns_athleteeventhistory": "Statistiken für alle Läufe dieses Athleten ansehen",
+    },
+    "www.parkrun.no": {
+        // Norweigen pages
+
+        // It's all in English
+    },
+    "www.parkrun.ru": {
+        // Russian pages
+        // http://www.parkrun.ru/bitsa/results/athletehistory/?athleteNumber=1551222
+        // http://www.parkrun.ru/results/athleteresultshistory/?athleteNumber=1551222
+        // http://www.parkrun.ru/results/athleteeventresultshistory/?athleteNumber=1551222&eventNumber=0
+        // Randomly partly in English
+        "link_view_stats_for_all_parkruns_athleteeventhistory": "Показать статистику этого спортсмена по всем забегам"
+        // But annoyingly, the volunteer roles have been translated in Russian,
+        // which doesn't happen on any other site
     }
 }
 

--- a/browser-extensions/chrome/js/lib/i18n.js
+++ b/browser-extensions/chrome/js/lib/i18n.js
@@ -50,6 +50,13 @@ var domains = {
         "table_all_results": "Alla resultat",
         "link_view_stats_for_all_parkruns": "Se statistik för alla parkruns av denna löpare",
         "link_view_stats_for_all_parkruns_athleteeventhistory": "Se statistik för alla parkruns av denna löpare",
+    },
+    "www.parkrun.fi": {
+        // Finnish pages
+        // http://www.parkrun.fi/tampere/results/athletehistory/?athleteNumber=4064283
+        // http://www.parkrun.fi/results/athleteresultshistory/?athleteNumber=4064283
+        // http://www.parkrun.fi/results/athleteeventresultshistory/?athleteNumber=4064283&eventNumber=0
+        // It is all in English
     }
 }
 

--- a/browser-extensions/chrome/js/lib/i18n.js
+++ b/browser-extensions/chrome/js/lib/i18n.js
@@ -1,0 +1,71 @@
+// This attempts to provide an interface for the code to be common, and yet
+// still work across all of the parkrun sites
+// Although most of the content is still in English, such as the parkrun names
+
+var domains = {
+    // Default english language options, good for most of the domains
+    "default": {
+        "url_athleteeventresultshistory": "results/athleteeventresultshistory/",
+        "table_all_results": "All Results",
+        "link_view_stats_for_all_parkruns": "View stats for all parkruns by this athlete",
+        "link_view_stats_for_all_parkruns_athleteeventhistory": "View stats for all parkruns by this athlete",
+        "link_all": "All",
+        // These variables contain text we output, so need translating by someone
+        "text_see_challenge_progress": "See challenge progress",
+        "text_running_challenges": "Running Challenges"
+    },
+    "www.parkrun.pl": {
+        // Polish pages
+        // http://www.parkrun.pl/warszawa-ursynow/rezultaty/athletehistory/?athleteNumber=546975
+        // http://www.parkrun.pl/rezultaty/athleteresultshistory/?athleteNumber=546975
+        // http://www.parkrun.pl/rezultaty/athleteeventresultshistory/?athleteNumber=546975&eventNumber=0
+        "url_athleteeventresultshistory": "rezultaty/athleteeventresultshistory/",
+        "table_all_results": "Wszystkie wyniki",
+        "link_view_stats_for_all_parkruns": "Zobacz statystyki uczestnika ze wszystkich biegów parkrun",
+        "link_view_stats_for_all_parkruns_athleteeventhistory": "Zobacz wyniki tego zawodnika ze wszystkich biegów",
+    },
+    "www.parkrun.it": {
+        // Italian pages
+        // http://www.parkrun.it/etna/results/athletehistory/?athleteNumber=3868619
+        // http://www.parkrun.it/results/athleteresultshistory/?athleteNumber=3868619
+        // http://www.parkrun.it/results/athleteeventresultshistory?athleteNumber=3868619&eventNumber=0
+        "table_all_results": "Tutti i risultati",
+        "link_view_stats_for_all_parkruns": "Visualizza statistiche per tutti i parkruns di questo atleta",
+        "link_view_stats_for_all_parkruns_athleteeventhistory": "Visualizza statistiche per tutti i parkruns di questo atleta",
+    },
+    "www.parkrun.dk": {
+        // Danish pages
+        // http://www.parkrun.dk/amagerstrandpark/results/athletehistory/?athleteNumber=3287153
+        // http://www.parkrun.dk/results/athleteresultshistory/?athleteNumber=3287153
+        // http://www.parkrun.dk/results/athleteeventresultshistory/?athleteNumber=3287153&eventNumber=0
+        "table_all_results": "Alle resultater",
+        "link_view_stats_for_all_parkruns": "Se tal for alle parkruns løbet af denne løber",
+        "link_view_stats_for_all_parkruns_athleteeventhistory": "Se tal for alle parkruns løbet af denne løber",
+    },
+    "www.parkrun.se": {
+        // Swedish pages
+        // http://www.parkrun.se/orebro/results/athletehistory/?athleteNumber=3899897
+        // http://www.parkrun.se/results/athleteresultshistory/?athleteNumber=3899897
+        // http://www.parkrun.se/results/athleteeventresultshistory/?athleteNumber=3899897&eventNumber=0
+        "table_all_results": "Alla resultat",
+        "link_view_stats_for_all_parkruns": "Se statistik för alla parkruns av denna löpare",
+        "link_view_stats_for_all_parkruns_athleteeventhistory": "Se statistik för alla parkruns av denna löpare",
+    }
+}
+
+function get_localised_value(param, domain=location.host) {
+    // Strip any leading http[s] protocol off the front of the domain
+    var domain = domain.replace(/^https?:\/\//,'')
+    if (domain in domains) {
+        if (param in domains[domain]) {
+            console.log("I18N:"+param+":"+domains[domain][param])
+            return domains[domain][param]
+        }
+    }
+    return get_localised_default_value(param)
+}
+
+function get_localised_default_value(param) {
+    console.log("I18N:"+param+":"+domains.default[param])
+    return domains.default[param]
+}

--- a/browser-extensions/chrome/js/translations.js
+++ b/browser-extensions/chrome/js/translations.js
@@ -1,0 +1,53 @@
+
+
+// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.
+function draw_translation_table() {
+
+    var table = $('<table/>', {
+        class: "simple_table"
+    })
+
+    english_translations = Object.keys(domains.default.text_volunteer_role_map).sort()
+    console.log(english_translations)
+
+    domain = Object.keys(domains.default.text_volunteer_role_map).sort()
+
+    var translation_map = {}
+
+    $.each(domains, function(domain, translations) {
+        if (domain == "default") {
+            return
+        }
+        console.log(domain)
+        if ("text_volunteer_role_map" in translations) {
+            var mapping = {}
+            console.log(translations.text_volunteer_role_map)
+            $.each(translations.text_volunteer_role_map, function(foreign, english) {
+                mapping[english] = foreign
+            })
+            translation_map[domain] = mapping
+        }
+    })
+    console.log(translation_map)
+    var h_row = $('<tr/>')
+    h_row.append($('<th/>').text('International English'))
+    $.each(Object.keys(translation_map).sort(), function(j, pr_lang) {
+        h_row.append($('<th/>').text(pr_lang))
+    })
+    table.append(h_row)
+
+    $.each(Object.keys(domains.default.text_volunteer_role_map).sort(), function(i, role) {
+        var row = $('<tr/>')
+        row.append($('<td/>').text(role))
+        $.each(Object.keys(translation_map).sort(), function(j, pr_lang) {
+            row.append($('<td/>').text(translation_map[pr_lang][role]))
+        })
+        table.append(row)
+    })
+
+    console.log(table)
+    $('[id=volunteer_roles]').append(table)
+}
+
+document.addEventListener('DOMContentLoaded', draw_translation_table);

--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -26,7 +26,8 @@
           "*://www.parkrun.co.za/results/athleteeventresultshistory/*",
           "*://www.parkrun.us/results/athleteeventresultshistory/*",
           "*://www.parkrun.sg/results/athleteeventresultshistory/*",
-          "*://www.parkrun.pl/rezultaty/athleteeventresultshistory/*"
+          "*://www.parkrun.pl/rezultaty/athleteeventresultshistory/*",
+          "*://www.parkrun.it/results/athleteeventresultshistory/*"
       ],
       "js": [
           "js/lib/third-party/jquery-3.3.1.js",
@@ -47,7 +48,8 @@
         "*://www.parkrun.co.za/results/athleteresultshistory/*",
         "*://www.parkrun.us/results/athleteresultshistory/*",
         "*://www.parkrun.sg/results/athleteresultshistory/*",
-        "*://www.parkrun.pl/rezultaty/athleteresultshistory/*"
+        "*://www.parkrun.pl/rezultaty/athleteresultshistory/*",
+        "*://www.parkrun.it/results/athleteresultshistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",
@@ -66,7 +68,8 @@
         "*://www.parkrun.co.za/*/results/athletehistory/*",
         "*://www.parkrun.us/*/results/athletehistory/*",
         "*://www.parkrun.sg/*/results/athletehistory/*",
-        "*://www.parkrun.pl/*/athletehistory/*"
+        "*://www.parkrun.pl/*/athletehistory/*",
+        "*://www.parkrun.it/*/athletehistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",

--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -28,7 +28,8 @@
           "*://www.parkrun.sg/results/athleteeventresultshistory/*",
           "*://www.parkrun.pl/rezultaty/athleteeventresultshistory/*",
           "*://www.parkrun.it/results/athleteeventresultshistory/*",
-          "*://www.parkrun.dk/results/athleteeventresultshistory/*"
+          "*://www.parkrun.dk/results/athleteeventresultshistory/*",
+          "*://www.parkrun.se/results/athleteeventresultshistory/*"
       ],
       "js": [
           "js/lib/third-party/jquery-3.3.1.js",
@@ -51,7 +52,8 @@
         "*://www.parkrun.sg/results/athleteresultshistory/*",
         "*://www.parkrun.pl/rezultaty/athleteresultshistory/*",
         "*://www.parkrun.it/results/athleteresultshistory/*",
-        "*://www.parkrun.dk/results/athleteresultshistory/*"
+        "*://www.parkrun.dk/results/athleteresultshistory/*",
+        "*://www.parkrun.se/results/athleteresultshistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",
@@ -72,7 +74,8 @@
         "*://www.parkrun.sg/*/results/athletehistory/*",
         "*://www.parkrun.pl/*/athletehistory/*",
         "*://www.parkrun.it/*/athletehistory/*",
-        "*://www.parkrun.dk/*/athletehistory/*"
+        "*://www.parkrun.dk/*/athletehistory/*",
+        "*://www.parkrun.se/*/athletehistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",

--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -25,7 +25,8 @@
           "*://www.parkrun.ie/results/athleteeventresultshistory/*",
           "*://www.parkrun.co.za/results/athleteeventresultshistory/*",
           "*://www.parkrun.us/results/athleteeventresultshistory/*",
-          "*://www.parkrun.sg/results/athleteeventresultshistory/*"
+          "*://www.parkrun.sg/results/athleteeventresultshistory/*",
+          "*://www.parkrun.pl/*/athleteeventresultshistory/*"
       ],
       "js": [
           "js/lib/third-party/jquery-3.3.1.js",
@@ -44,7 +45,8 @@
         "*://www.parkrun.ie/results/athleteresultshistory/*",
         "*://www.parkrun.co.za/results/athleteresultshistory/*",
         "*://www.parkrun.us/results/athleteresultshistory/*",
-        "*://www.parkrun.sg/results/athleteresultshistory/*"
+        "*://www.parkrun.sg/results/athleteresultshistory/*",
+        "*://www.parkrun.pl/*/athleteresultshistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",
@@ -61,7 +63,8 @@
         "*://www.parkrun.ie/*/results/athletehistory/*",
         "*://www.parkrun.co.za/*/results/athletehistory/*",
         "*://www.parkrun.us/*/results/athletehistory/*",
-        "*://www.parkrun.sg/*/results/athletehistory/*"
+        "*://www.parkrun.sg/*/results/athletehistory/*",
+        "*://www.parkrun.pl/*/athletehistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",

--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -26,10 +26,11 @@
           "*://www.parkrun.co.za/results/athleteeventresultshistory/*",
           "*://www.parkrun.us/results/athleteeventresultshistory/*",
           "*://www.parkrun.sg/results/athleteeventresultshistory/*",
-          "*://www.parkrun.pl/*/athleteeventresultshistory/*"
+          "*://www.parkrun.pl/rezultaty/athleteeventresultshistory/*"
       ],
       "js": [
           "js/lib/third-party/jquery-3.3.1.js",
+          "js/lib/i18n.js",
           "js/lib/challenges.js",
           "js/lib/challenges_ui.js",
           "js/content-scripts/content-script-athleteeventresultshistory.js"
@@ -46,10 +47,11 @@
         "*://www.parkrun.co.za/results/athleteresultshistory/*",
         "*://www.parkrun.us/results/athleteresultshistory/*",
         "*://www.parkrun.sg/results/athleteresultshistory/*",
-        "*://www.parkrun.pl/*/athleteresultshistory/*"
+        "*://www.parkrun.pl/rezultaty/athleteresultshistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",
+        "js/lib/i18n.js",
         "js/content-scripts/content-script-athleteresultshistory.js"
     ],
     "run_at": "document_end"
@@ -68,6 +70,7 @@
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",
+        "js/lib/i18n.js",
         "js/content-scripts/content-script-athleteeventhistory.js"
     ],
     "run_at": "document_end"
@@ -91,6 +94,7 @@
     "persistent": true,
     "scripts": [
         "js/lib/third-party/jquery-3.3.1.js",
+        "js/lib/i18n.js",
         "js/background.js"
     ]
   }

--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -27,7 +27,8 @@
           "*://www.parkrun.us/results/athleteeventresultshistory/*",
           "*://www.parkrun.sg/results/athleteeventresultshistory/*",
           "*://www.parkrun.pl/rezultaty/athleteeventresultshistory/*",
-          "*://www.parkrun.it/results/athleteeventresultshistory/*"
+          "*://www.parkrun.it/results/athleteeventresultshistory/*",
+          "*://www.parkrun.dk/results/athleteeventresultshistory/*"
       ],
       "js": [
           "js/lib/third-party/jquery-3.3.1.js",
@@ -49,7 +50,8 @@
         "*://www.parkrun.us/results/athleteresultshistory/*",
         "*://www.parkrun.sg/results/athleteresultshistory/*",
         "*://www.parkrun.pl/rezultaty/athleteresultshistory/*",
-        "*://www.parkrun.it/results/athleteresultshistory/*"
+        "*://www.parkrun.it/results/athleteresultshistory/*",
+        "*://www.parkrun.dk/results/athleteresultshistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",
@@ -69,7 +71,8 @@
         "*://www.parkrun.us/*/results/athletehistory/*",
         "*://www.parkrun.sg/*/results/athletehistory/*",
         "*://www.parkrun.pl/*/athletehistory/*",
-        "*://www.parkrun.it/*/athletehistory/*"
+        "*://www.parkrun.it/*/athletehistory/*",
+        "*://www.parkrun.dk/*/athletehistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",

--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -29,7 +29,8 @@
           "*://www.parkrun.pl/rezultaty/athleteeventresultshistory/*",
           "*://www.parkrun.it/results/athleteeventresultshistory/*",
           "*://www.parkrun.dk/results/athleteeventresultshistory/*",
-          "*://www.parkrun.se/results/athleteeventresultshistory/*"
+          "*://www.parkrun.se/results/athleteeventresultshistory/*",
+          "*://www.parkrun.fi/results/athleteeventresultshistory/*"
       ],
       "js": [
           "js/lib/third-party/jquery-3.3.1.js",
@@ -53,7 +54,8 @@
         "*://www.parkrun.pl/rezultaty/athleteresultshistory/*",
         "*://www.parkrun.it/results/athleteresultshistory/*",
         "*://www.parkrun.dk/results/athleteresultshistory/*",
-        "*://www.parkrun.se/results/athleteresultshistory/*"
+        "*://www.parkrun.se/results/athleteresultshistory/*",
+        "*://www.parkrun.fi/results/athleteresultshistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",
@@ -75,7 +77,8 @@
         "*://www.parkrun.pl/*/athletehistory/*",
         "*://www.parkrun.it/*/athletehistory/*",
         "*://www.parkrun.dk/*/athletehistory/*",
-        "*://www.parkrun.se/*/athletehistory/*"
+        "*://www.parkrun.se/*/athletehistory/*",
+        "*://www.parkrun.fi/*/athletehistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",

--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -104,7 +104,8 @@
       "/images/badges/*.png",
       "/images/logo/*.png",
       "/images/flags/**/*.png",
-      "/html/*.html"
+      "/html/*.html",
+      "/css/*.css"
   ],
   "permissions": [
     "activeTab",

--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -30,7 +30,11 @@
           "*://www.parkrun.it/results/athleteeventresultshistory/*",
           "*://www.parkrun.dk/results/athleteeventresultshistory/*",
           "*://www.parkrun.se/results/athleteeventresultshistory/*",
-          "*://www.parkrun.fi/results/athleteeventresultshistory/*"
+          "*://www.parkrun.fi/results/athleteeventresultshistory/*",
+          "*://www.parkrun.fr/results/athleteeventresultshistory/*",
+          "*://www.parkrun.no/results/athleteeventresultshistory/*",
+          "*://www.parkrun.com.de/results/athleteeventresultshistory/*",
+          "*://www.parkrun.ru/results/athleteeventresultshistory/*"
       ],
       "js": [
           "js/lib/third-party/jquery-3.3.1.js",
@@ -55,7 +59,11 @@
         "*://www.parkrun.it/results/athleteresultshistory/*",
         "*://www.parkrun.dk/results/athleteresultshistory/*",
         "*://www.parkrun.se/results/athleteresultshistory/*",
-        "*://www.parkrun.fi/results/athleteresultshistory/*"
+        "*://www.parkrun.fi/results/athleteresultshistory/*",
+        "*://www.parkrun.fr/results/athleteresultshistory/*",
+        "*://www.parkrun.com.de/results/athleteresultshistory/*",
+        "*://www.parkrun.no/results/athleteresultshistory/*",
+        "*://www.parkrun.ru/results/athleteresultshistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",
@@ -78,7 +86,11 @@
         "*://www.parkrun.it/*/athletehistory/*",
         "*://www.parkrun.dk/*/athletehistory/*",
         "*://www.parkrun.se/*/athletehistory/*",
-        "*://www.parkrun.fi/*/athletehistory/*"
+        "*://www.parkrun.fi/*/athletehistory/*",
+        "*://www.parkrun.fr/*/athletehistory/*",
+        "*://www.parkrun.com.de/*/athletehistory/*",
+        "*://www.parkrun.no/*/athletehistory/*",
+        "*://www.parkrun.ru/*/athletehistory/*"
     ],
     "js": [
         "js/lib/third-party/jquery-3.3.1.js",


### PR DESCRIPTION
  - For #38 
  - Supports including badges on Italian, Danish, Swedish, Finnish, French, German, Norweigan, and Russian websites
  - Attempts to credit volunteering on all of the above too, but we are missing some translations of the roles, although some are in English so it was fine out of the box
  - Abstracts the strings we look for in the page into an internationalisation (i18n) file and function so that we can add more languages easily. This is required when adding a new site.
  - Also allows for translation of some of the link we add into the pages, but we don't have a good way of generating reasonable translations, so will probably asking for help of the community if they want it