### PR TITLE
Skip future parkruns

### DIFF
--- a/browser-extensions/chrome/html/options.html
+++ b/browser-extensions/chrome/html/options.html
@@ -19,6 +19,13 @@ Home country: <span id="athlete_home_country_div">loading...</span>
 
 <button id="save">Save</button> <span id="status"></span>
 
+<div id=debug_home_parkrun_info>
+<p>
+<h4>Home Parkrun Info</h4>
+Info: <span id='home_parkrun_info'>unknown</span><br/>
+</p>
+</div>
+
 <div id=debug_parkrun_info>
 <p>
 <h4>Parkrun Info</h4>

--- a/browser-extensions/chrome/html/options.html
+++ b/browser-extensions/chrome/html/options.html
@@ -16,17 +16,20 @@ Home parkrun: <span id="athlete_home_parkrun_div">
 </span><br/>
 Home country: <span id="athlete_home_country_div">loading...</span>
 </p>
-<div id="status"></div>
-<button id="save">Save</button>
 
+<button id="save">Save</button> <span id="status"></span>
+
+<div id=debug_parkrun_info>
 <p>
-<h4>Geo Cache Info</h4>
+<h4>Parkrun Info</h4>
 Last updated: <span id='cached_geo_updated'>unknown</span><br/>
 Known Events: <span id='cached_geo_events'>unknown</span><br/>
 Known Countries: <span id='cached_geo_countries'>unknown</span><br/>
 Known Regions: <span id='cached_geo_regions'>unknown</span><br/>
 Size (bytes): <span id='cached_geo_bytes'>unknown</span><br/>
+<button id="update_cache">Update Cache</button>
 </p>
+</div>
 
 <h4>Feedback</h4>
 <p>

--- a/browser-extensions/chrome/js/options.js
+++ b/browser-extensions/chrome/js/options.js
@@ -89,8 +89,8 @@ function save_user_configuration() {
     // Build up our information that we want to save.
     // Fetch the home parkrun info
     var saved_data = {
-      athlete_number: athlete_number,
-      home_parkrun_info: get_home_parkrun_info(athlete_home_parkrun)
+        athlete_number: athlete_number,
+        home_parkrun_info: get_home_parkrun_info(athlete_home_parkrun)
     }
 
     // Store it on the page for future use
@@ -100,12 +100,12 @@ function save_user_configuration() {
     console.log('Saving: '+JSON.stringify(saved_data))
 
     chrome.storage.sync.set(saved_data, function() {
-      // Update status to let user know options were saved.
-      var status = document.getElementById('status');
-      status.textContent = 'Options saved.';
-      setTimeout(function() {
-        status.textContent = '';
-      }, 750);
+        // Update status to let user know options were saved.
+        var status = document.getElementById('status');
+        status.textContent = 'Options saved.';
+        setTimeout(function() {
+            status.textContent = '';
+        }, 750);
     });
 }
 
@@ -113,15 +113,15 @@ function load_user_configuration() {
     console.log('load_user_configuration()')
     var restored_options = null
     chrome.storage.sync.get({
-      athlete_number: '',
-      home_parkrun_info: {}
+        athlete_number: '',
+        home_parkrun_info: {}
     }, function(items) {
         // Store it on the page for future use
         saved_options = items
-      console.log('Loaded: '+JSON.stringify(items))
-      $('#athlete_number').val(items.athlete_number);
-      // Update the home parkrun dropdown with the loaded value, if present
-      update_home_parkrun_dropdown()
+        console.log('Loaded: '+JSON.stringify(items))
+        $('#athlete_number').val(items.athlete_number);
+        // Update the home parkrun dropdown with the loaded value, if present
+        update_home_parkrun_dropdown()
     });
 }
 

--- a/browser-extensions/chrome/js/options.js
+++ b/browser-extensions/chrome/js/options.js
@@ -1,72 +1,157 @@
 var geo_data = null
+var saved_options = {}
 
-// Saves options to chrome.storage
-function save_options() {
-  var athlete_number = document.getElementById('athlete_number').value;
-  var athlete_home_parkrun = document.getElementById('athlete_home_parkrun').value;
+function initial_page_setup() {
 
-  var saved_data = {
-    athlete_number: athlete_number,
-    home_parkrun_info: {}
-  }
+    // Attach the save function to the 'Save' button
+    $('#save').click(function() {
+        save_user_configuration()
+    })
+    // Watch for changes to the athlete id textbox
+    $('#athlete_number').bind('keyup change', function() {
+        on_change_athlete_number()
+    })
+    // Attach the clear-cache function to the 'Update Cache' button
+    $('#update_cache').click(function() {
+        update_cache(true)
+    })
+    // Attach the handler to update the parkrun home country when the select
+    // dropdown is changed
+    $('#athlete_home_parkrun').change(function() {
+        update_home_parkrun_country()
+    })
 
-  // Look up extra pieces of information for this parkrun.
-  if (athlete_home_parkrun in geo_data.data.events) {
-      home_event_info = geo_data.data.events[athlete_home_parkrun]
-      console.log('Found info: ')
-      console.log(home_event_info)
-      saved_data.home_parkrun_info = home_event_info
-  }
+    // Hide the debug elements by default, only showing them if you set the
+    // athlete number to 'testing'
+    show_debug_elements(false)
 
+    // Load the user configuration so that we can display it
+    load_user_configuration()
 
-  console.log('Saving: '+JSON.stringify(saved_data))
+    // Fetch all the parkrun statistics so that we populate things like the
+    // home parkrun dropdown, and the cache information
+    update_cache()
 
-  chrome.storage.sync.set(saved_data, function() {
-    // Update status to let user know options were saved.
-    var status = document.getElementById('status');
-    status.textContent = 'Options saved.';
-    setTimeout(function() {
-      status.textContent = '';
-    }, 750);
-  });
 }
 
-// Restores select box and checkbox state using the preferences
-// stored in chrome.storage.
-function restore_options() {
-  // Use default value color = 'red' and likesColor = true.
-  var restored_options = null
-  chrome.storage.sync.get({
-    athlete_number: '',
-    home_parkrun_info: {}
-  }, function(items) {
-    restored_options = items
-    console.log('Loaded: '+JSON.stringify(restored_options))
-    document.getElementById('athlete_number').value = items.athlete_number;
-  });
+function on_change_athlete_number() {
+    var athlete_number = $('#athlete_number').val();
+    // Special case if the contents is now 'testing', we show the hidden debug info
+    if (athlete_number == 'testing') {
+        show_debug_elements(true)
+    } else {
+        show_debug_elements(false)
+    }
+}
 
-  // Load the GEO data with a timeout
-  var timeout_for_geo_data_ms = 5000
+function show_debug_elements(visible=false) {
+    // A set of element IDs that will be shown/hidden depending on whether
+    // we are in a debug mode, as determined by the parameter to this function
+    var debug_elements = [
+        "debug_parkrun_info"
+    ]
+    $.each(debug_elements, function(index, id) {
+        // Find the element IDs and show or hide them as appropriate
+        if (visible) {
+            $('#'+id).show()
+        } else {
+            $('#'+id).hide()
+        }
+    })
+}
 
-  var timeoutProtect = setTimeout(function() {
-    // Clear the local timer variable, indicating the timeout has been triggered.
-    timeoutProtect = null;
-    // Display the data without geo data
-    display_data(challenge_settings)
+function get_home_parkrun_info(parkrun_event_name) {
+    // Look up extra pieces of information for this parkrun, if available
+    console.log('looking up info for home parkrun '+parkrun_event_name)
+    if (geo_data !== null) {
+        if (parkrun_event_name in geo_data.data.events) {
+            home_event_info = geo_data.data.events[parkrun_event_name]
+            console.log('Found info for '+parkrun_event_name+': '+JSON.stringify(home_event_info))
+            return home_event_info
+        }
+    }
+    // Have a last check to see if we know about this from a previous lookup
+    // which we loaded from disk
+    if ('home_parkrun_info' in saved_options && saved_options.home_parkrun_info.name == parkrun_event_name) {
+        return saved_options.home_parkrun_info
+    }
 
-  }, timeout_for_geo_data_ms);
+    // Else return no interesting information
+    return {}
+}
 
-  // Prepopulate the event info cache why not
-  chrome.runtime.sendMessage({data: "event_info"}, function(response) {
-      console.log(response)
-  })
+function save_user_configuration() {
+    console.log('save_user_configuration()')
 
-  chrome.runtime.sendMessage({data: "geo"}, function(response) {
-      // Proceed only if the timeout handler has not yet fired.
-      if (timeoutProtect) {
-        // Clear the scheduled timeout handler
-        clearTimeout(timeoutProtect);
-        geo_data = response.geo
+    var athlete_number = $('#athlete_number').val();
+    var athlete_home_parkrun = $('#athlete_home_parkrun').val();
+
+    // Build up our information that we want to save.
+    // Fetch the home parkrun info
+    var saved_data = {
+      athlete_number: athlete_number,
+      home_parkrun_info: get_home_parkrun_info(athlete_home_parkrun)
+    }
+
+    // Store it on the page for future use
+    saved_options = saved_data
+    update_home_parkrun_country()
+
+    console.log('Saving: '+JSON.stringify(saved_data))
+
+    chrome.storage.sync.set(saved_data, function() {
+      // Update status to let user know options were saved.
+      var status = document.getElementById('status');
+      status.textContent = 'Options saved.';
+      setTimeout(function() {
+        status.textContent = '';
+      }, 750);
+    });
+}
+
+function load_user_configuration() {
+    console.log('load_user_configuration()')
+    var restored_options = null
+    chrome.storage.sync.get({
+      athlete_number: '',
+      home_parkrun_info: {}
+    }, function(items) {
+        // Store it on the page for future use
+        saved_options = items
+      console.log('Loaded: '+JSON.stringify(items))
+      $('#athlete_number').val(items.athlete_number);
+      // Update the home parkrun dropdown with the loaded value, if present
+      update_home_parkrun_dropdown()
+    });
+}
+
+function update_cache(force_update=false) {
+    console.log('update_cache()')
+    // Send a message to the background page to request the geo data
+    chrome.runtime.sendMessage({data: "geo", freshen: force_update}, function(response) {
+        if (response !== null && 'geo' in response) {
+            // Save the data on the page for future use
+            geo_data = response.geo
+            // Update the parts of the UI that show information relating to,
+            // or based on, the geo data
+            update_geo_data_stats()
+            update_home_parkrun_dropdown()
+        }
+    });
+}
+
+function update_geo_data_stats() {
+    console.log('update_geo_data_stats()')
+    var s_last_update = "-"
+    var s_known_regions = "0"
+    var s_known_countries = "0"
+    var s_known_events = "0"
+    var s_geo_data_bytes = "0"
+
+    if (geo_data !== null) {
+        s_last_update = geo_data.updated;
+        s_known_countries = Object.keys(geo_data.data.countries).length;
+        s_known_regions = Object.keys(geo_data.data.regions).length;
 
         known_events_states = {}
 
@@ -77,55 +162,96 @@ function restore_options() {
             known_events_states[event_info.status] += 1
         })
 
-        // Fill in some summary data on the options page
-        document.getElementById('cached_geo_updated').innerText = geo_data.updated;
-        document.getElementById('cached_geo_events').innerText = JSON.stringify(known_events_states);
-        document.getElementById('cached_geo_countries').innerText = Object.keys(geo_data.data.countries).length;
-        document.getElementById('cached_geo_regions').innerText = Object.keys(geo_data.data.regions).length;
-        document.getElementById('cached_geo_bytes').innerText =  JSON.stringify(geo_data).length;
+        s_known_events = JSON.stringify(known_events_states);
+        s_geo_data_bytes =  JSON.stringify(geo_data).length;
+    }
 
-        // Fill in the home parkrun selection dropdown
-        home_parkrun_select = $("[id=athlete_home_parkrun]")
+    $('#cached_geo_updated').text(s_last_update)
+    $('#cached_geo_regions').text(s_known_regions)
+    $('#cached_geo_countries').text(s_known_countries)
+    $('#cached_geo_events').text(s_known_events)
+    $('#cached_geo_bytes').text(s_geo_data_bytes)
+
+}
+
+function update_home_parkrun_dropdown() {
+    console.log('update_home_parkrun_dropdown()')
+
+    var home_parkrun_select = $("#athlete_home_parkrun")
+
+    var not_set_option = $('<option/>',
+    {
+        value: 'Not Set',
+        text: "Not Set"
+    })
+
+    // Clear all the existing keys
+    home_parkrun_select.empty()
+    home_parkrun_select.append(not_set_option)
+
+    if (geo_data !== null) {
+
+        // Iterate over all the available events that we know about
         Object.keys(geo_data.data.events).forEach(function (event_name) {
             event_o = geo_data.data.events[event_name]
-            // if (region_o.parent_id == "1") {
+            // Create a suitable option for this event
             var select_option = $('<option/>', {
                 value: event_o.name
             })
+            // Add a suffix to indicate if this is a new parkrun
             if (event_o.status === 'Live') {
                 select_option.text(event_o.name)
             } else {
                 select_option.text(event_o.name + " ("+event_o.status+")")
             }
+            // Add it to the options dropdown list
             home_parkrun_select.append(select_option)
-            // }
         })
 
-        if ("name" in restored_options.home_parkrun_info) {
-            home_parkrun_select.val(restored_options.home_parkrun_info.name)
+        // Set the home parkrun we know about if we have it in the list, else
+        // default to Not Set
+        if ("name" in saved_options.home_parkrun_info) {
+            home_parkrun_select.val(saved_options.home_parkrun_info.name)
+        } else {
+            home_parkrun_select.val('Not Set')
         }
-        update_home_country()
 
-        // Add on-change listener to the select box
-        home_parkrun_select.change(update_home_country)
-    }
-  });
-
-}
-
-function update_home_country() {
-    var h_parkrun = $("[id=athlete_home_parkrun]").val()
-    if (h_parkrun === null || h_parkrun == "Not Set") {
-        $("[id=athlete_home_country_div]").text("Not Set")
-    } else if (h_parkrun in geo_data.data.events) {
-        var h_country = geo_data.data.events[h_parkrun].country_name
-        $("[id=athlete_home_country_div]").text(h_country)
     } else {
-        $("[id=athlete_home_country_div]").text("Unknown")
+
+        // If the user has set their home parkrun already, then add it into the
+        // list anyway and select that
+        if ("name" in saved_options.home_parkrun_info) {
+            var existing_home_parkrun_option = $('<option/>',
+            {
+                value: saved_options.home_parkrun_info.name,
+                text: saved_options.home_parkrun_info.name
+            })
+            home_parkrun_select.append(existing_home_parkrun_option)
+            home_parkrun_select.val(saved_options.home_parkrun_info.name)
+        } else {
+            home_parkrun_select.val('Not Set')
+        }
+
+    }
+    update_home_parkrun_country()
+}
+
+function update_home_parkrun_country() {
+    console.log('update_home_parkrun_country()')
+    var h_parkrun = $("#athlete_home_parkrun").val()
+    var h_parkrun_div = $("#athlete_home_country_div")
+
+    var p_info = get_home_parkrun_info(h_parkrun)
+    console.log(p_info)
+    if ('country_name' in p_info) {
+        h_parkrun_div.text(p_info.country_name)
+    } else {
+        h_parkrun_div.text("Unknown")
     }
 
 }
 
-document.addEventListener('DOMContentLoaded', restore_options);
-document.getElementById('save').addEventListener('click',
-    save_options);
+// Code to run when the document's DOM is ready
+$( document ).ready(function() {
+    initial_page_setup()
+});

--- a/browser-extensions/chrome/js/options.js
+++ b/browser-extensions/chrome/js/options.js
@@ -48,7 +48,8 @@ function show_debug_elements(visible=false) {
     // A set of element IDs that will be shown/hidden depending on whether
     // we are in a debug mode, as determined by the parameter to this function
     var debug_elements = [
-        "debug_parkrun_info"
+        "debug_parkrun_info",
+        "debug_home_parkrun_info"
     ]
     $.each(debug_elements, function(index, id) {
         // Find the element IDs and show or hide them as appropriate
@@ -248,6 +249,8 @@ function update_home_parkrun_country() {
     } else {
         h_parkrun_div.text("Unknown")
     }
+
+    $("#home_parkrun_info").text(JSON.stringify(p_info, null, 4))
 
 }
 

--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -5,7 +5,7 @@
   "description": "Adds challenge progress information to your parkrun athlete results page.",
   "version": "0.2.0.8",
 
-  "content_security_policy": "default-src 'self' https://www.parkrun.org.uk",
+  "content_security_policy": "default-src 'self' https://www.parkrun.org.uk https://wiki.parkrun.com",
 
   "browser_action": {
     "default_icon": "images/logo/logo-128x128.png"
@@ -109,7 +109,9 @@
   ],
   "permissions": [
     "activeTab",
-    "storage"
+    "storage",
+    "https://www.parkrun.org.uk/",
+    "https://wiki.parkrun.com/"
   ],
   "options_ui": {
       "page": "html/options.html",


### PR DESCRIPTION
  - For #28 
  - Fetch the Technical Event Information as well as the Geo XML (in parallel),
    defaulting to previously fetched contents if we can't fetch the new info for some
    reason when the cache has expired
  - Update the manifest to allow fetching of data from wiki.parkrun.com
  - Set the cache expiry to 3 days for the technical information to match that for 
    the Geo XML
  - Hide the debug information on the options page unless you give you athlete number as 'testing'
  - Add 'Update Cache' button to the hidden options panel
  - Add home parkrun information to the hidden options panel
  - Rewrite most of the `options.js` page to cope with failures to fetch data
  - Rewrite big chunks of `background.js` to handle incremental fetching of data
