### PR TITLE
Add Google Analytics to production website

### DIFF
--- a/build/website/build.sh
+++ b/build/website/build.sh
@@ -33,6 +33,9 @@ SITE_DIR=_site
 # Clear out the build directory
 rm -rf ${SITE_DIR} && mkdir ${SITE_DIR}
 
+# Set the production flag
+export JEKYLL_ENV=production
+
 # Build the site
 bundle install
 bundle exec jekyll build

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -65,3 +65,5 @@ show_excerpts: true
 # To build with Docker:
 # cd running-challenges/blog
 # docker run --rm --name jekyll -it -p 4000:4000 -v `pwd`:/srv/jekyll -v `pwd`/vendor/bundle:/usr/local/bundle jekyll/jekyll jekyll serve
+
+google_analytics: "UA-115520338-2"


### PR DESCRIPTION
  - Add analytics ID to the main configuration
  - Set the production build to use JEKYLL_ENV=production so that it is activated for this build