### PR TITLE
Trim whitespace during results table parse.

### DIFF
--- a/browser-extensions/common/js/content-scripts/content-script-athleteeventresultshistory.js
+++ b/browser-extensions/common/js/content-scripts/content-script-athleteeventresultshistory.js
@@ -162,11 +162,11 @@ function parse_results_table() {
           table_cells = $("td", this)
           if (table_cells.length > 0) {
               // Find the name and other interesting bits of data for this parkrun
-              parkrun_name = table_cells[0].innerText
-              parkrun_date = table_cells[1].innerText
-              parkrun_event_number = table_cells[2].innerText
-              parkrun_position = table_cells[3].innerText
-              parkrun_time = table_cells[4].innerText
+              parkrun_name = table_cells[0].innerText.trim()
+              parkrun_date = table_cells[1].innerText.trim()
+              parkrun_event_number = table_cells[2].innerText.trim()
+              parkrun_position = table_cells[3].innerText.trim()
+              parkrun_time = table_cells[4].innerText.trim()
               parkrun_pb = table_cells[6].innerText.trim()
 
               // Create a date object, useful for comparing


### PR DESCRIPTION
I've been seeing some problems parsing the results table - at least on Chrome 70.0.3538.67.  Additional whitespace appearing in the innerText attribute prevents the extension from working correctly.  Adding trim() for each piece of data helps resolve the issue.