### PR TITLE
Restrict building staging website to PRs from our own repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ before_script:
  - npm install -g web-ext
 
 script:
-   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash ./build/website/build-staging.sh; fi'
+   # Only build the staging website if the github token is available, which means
+   # that it will only happen for PRs from our own repo, not forks.
+   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then if [ "$RUNNING_CHALLENGES_GITHUB_TOKEN" != "" ]; then bash ./build/website/build-staging.sh; fi; fi'
    - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./build/website/build.sh; fi'
    - './build/extension-chrome/build.sh'
    - './build/extension-firefox/build.sh'


### PR DESCRIPTION
  - Travis only makes secret variables available to PRs from the project's own repository, 
    i.e. not forks, which means that the builds fail for any external PRs. This should skip the
    staging website build for this type of contribution so that the build isn't marked as failed