### PR TITLE
Remove error from parsing Technical Event Information page

### DIFF
--- a/browser-extensions/common/js/background.js
+++ b/browser-extensions/common/js/background.js
@@ -316,7 +316,13 @@ function parse_tee_data_event_status(data, result) {
 
   // Reset the event status data to a blank map
   data.event_status = {}
-  $(result).find('div[id=mw-content-text]>table:first').each(function(table_index) {
+
+  var ownerDocument = document.implementation.createHTMLDocument('virtual');
+  // Load the results into a virtual document, so that it doesn't attempt to load
+  // inline scripts etc...
+  // Solution taken from https://stackoverflow.com/questions/15113910/jquery-parse-html-without-loading-images
+  // referencing https://api.jquery.com/jQuery/ & https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createHTMLDocument
+  $(result, ownerDocument).find('div[id=mw-content-text]>table:first').each(function(table_index) {
      var content_table = $(this)
 
      content_table.find('tbody>tr').each(function(row_index) {


### PR DESCRIPTION
  - Avoids a huge splat of errors that occurs when JQuery tries to follow all the links in the 
    wiki page it loads 

  <img width="1493" alt="screen shot 2018-10-21 at 22 02 26" src="https://user-images.githubusercontent.com/2786011/47272409-213bde00-d57d-11e8-81bd-84e33603db43.png">
 
  Instead it is much cleaner

  <img width="890" alt="screen shot 2018-10-21 at 22 04 17" src="https://user-images.githubusercontent.com/2786011/47272417-46c8e780-d57d-11e8-80ed-ed5cd9d066e5.png">
