### PR TITLE
Strip v from version string

### DIFF
--- a/build/version.sh
+++ b/build/version.sh
@@ -1,4 +1,4 @@
-export VERSION=0.7.0
+export VERSION=0.7.1
 # Strip any 'v' characters from the version string, as exist in the git tag
 export EXTENSION_BUILD_VERSION=`echo ${EXTENSION_BUILD_VERSION:-$VERSION} | sed -e s/v//`
 # Default the build id variable to zero if not set - Travis should set this to

--- a/build/version.sh
+++ b/build/version.sh
@@ -1,5 +1,6 @@
 export VERSION=0.7.0
-export EXTENSION_BUILD_VERSION=${EXTENSION_BUILD_VERSION:-$VERSION}
+# Strip any 'v' characters from the version string, as exist in the git tag
+export EXTENSION_BUILD_VERSION=`echo ${EXTENSION_BUILD_VERSION:-$VERSION} | sed -e s/v//`
 # Default the build id variable to zero if not set - Travis should set this to
 # the Travis build number
 export EXTENSION_BUILD_ID=${EXTENSION_BUILD_ID:-0}


### PR DESCRIPTION
  - Make the git branch coexist with the need to put the version string in the `manifest.json`