### PR TITLE
Add browser polyfill to library path on Chrome for links

### DIFF
--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -80,6 +80,7 @@
         "*://www.parkrun.ru/results/athleteresultshistory/*"
     ],
     "js": [
+        "js/lib/third-party/browser-polyfill/browser-polyfill-76eeeac.js",
         "js/lib/third-party/jquery/jquery-3.3.1.js",
         "js/lib/i18n.js",
         "js/content-scripts/content-script-athleteresultshistory.js"
@@ -107,6 +108,7 @@
         "*://www.parkrun.ru/*/athletehistory/*"
     ],
     "js": [
+        "js/lib/third-party/browser-polyfill/browser-polyfill-76eeeac.js",
         "js/lib/third-party/jquery/jquery-3.3.1.js",
         "js/lib/i18n.js",
         "js/content-scripts/content-script-athleteeventhistory.js"


### PR DESCRIPTION
  - None of the links were showing in Chrome because the browser polyfill
    was missing and there was an error thrown when trying to get the icon.