### PR TITLE
Add link to openstreetmap for average parkrun location

### DIFF
--- a/browser-extensions/common/js/lib/challenges.js
+++ b/browser-extensions/common/js/lib/challenges.js
@@ -537,14 +537,20 @@ function generate_stat_average_parkrun_location(parkrun_results, geo_data) {
   })
 
   var value = "None"
+  var url_link = undefined
   if (count > 0) {
-    value = (lat_sum/count).toFixed(5) + "," + (lon_sum/count).toFixed(5)
+    var lat_av = (lat_sum/count).toFixed(5)
+    var lon_av = (lon_sum/count).toFixed(5)
+    value =  lat_av + "," + lon_av
+    // Provide a link to an openstreetmap with a marker in the location
+    url_link = "https://www.openstreetmap.org/?mlat="+lat_av+"&mlon="+lon_av+"#map=9/"+lat_av+"/"+lon_av
   }
 
   return {
     "display_name": "Average parkrun lat/lon location",
     "help": "The average latitude/longitude of all your parkrun attendances.",
-    "value": value
+    "value": value,
+    "url": url_link
   }
 }
 

--- a/browser-extensions/common/js/lib/challenges_ui.js
+++ b/browser-extensions/common/js/lib/challenges_ui.js
@@ -959,7 +959,11 @@ function add_stats_table(div, data) {
         stat_value = '<span style="cursor: default" title="'+stat_info.help+'">'+stat_value+'</span>'
       }
       row.append($('<td/>').html(display_name))
-      row.append($('<td/>').html(stat_value))
+      if (stat_info.url !== undefined) {
+        row.append($('<td/>').append($('<a/>', {href: stat_info.url, text: stat_info.value, target: "_blank", title: stat_info.help })))
+      } else {
+        row.append($('<td/>').html(stat_value))
+      }
       table.append(row)
     })
 


### PR DESCRIPTION
  - For #120 
  - Adds a link that opens in a new tab for the average location stat
  - The map is openstreetmap
  - Also adds a marker in the middle so you can see where it is as you zoom and scroll about.
  - Enables any other stat to gain a url if they should want it