### PR TITLE
Add v0.7.4 release

### DIFF
--- a/build/version.sh
+++ b/build/version.sh
@@ -1,4 +1,4 @@
-export VERSION=0.7.3
+export VERSION=0.7.4
 # Strip any 'v' characters from the version string, as exist in the git tag
 export EXTENSION_BUILD_VERSION=`echo ${EXTENSION_BUILD_VERSION:-$VERSION} | sed -e s/v//`
 # Default the build id variable to zero if not set - Travis should set this to

--- a/build/website/build-local-and-run.sh
+++ b/build/website/build-local-and-run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# This script pushing the built copy of the this site to a staging repository
+
+# Enable exit on failure
+set -e
+
+echo "Copying shared resources to the website folder"
+
+echo "Copying badges to website img/badges directory"
+mkdir -p website/img/badges
+cp -r images/badges/256x256/*.png website/img/badges/
+
+echo "Copying flags to website img/flags directory"
+mkdir -p website/img/flags
+cp -r images/flags/twemoji/png/*.png website/img/flags/
+
+echo "Copying logos to website img/logo directory"
+mkdir -p website/img/logo
+cp -r images/logo/*.png website/img/logo/
+
+echo "Copying screenshots to website img/screenshots directory"
+mkdir -p website/img/screenshots
+cp -r images/screenshots/*.png website/img/screenshots/
+
+# based on https://jekyllrb.com/docs/continuous-integration/travis-ci/
+
+# Move into the website directory
+cd website
+
+SITE_DIR=_site
+
+# Clear out the build directory
+rm -rf ${SITE_DIR} && mkdir ${SITE_DIR}
+
+docker run --rm --name jekyll \
+-p 4000:4000 \
+-v `pwd`:/srv/jekyll \
+-v `pwd`/vendor/bundle:/usr/local/bundle \
+jekyll/jekyll jekyll serve
+
+# Print summary
+echo "Built site, total size: `du -sh ${SITE_DIR}`"

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -56,6 +56,8 @@ header_pages:
   - _pages/faq.md
   - _pages/getstarted.md
 
+permalink: /:year/:month/:day/:title:output_ext
+
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.

--- a/website/_posts/2018-12-03-v0.7.4-released.markdown
+++ b/website/_posts/2018-12-03-v0.7.4-released.markdown
@@ -1,0 +1,37 @@
+---
+layout: post
+title:  "Version 0.7.4 Released"
+date:   2018-12-03 23:00:00 +0000
+categories:
+  - chrome-extension
+  - firefox-addon
+  - release
+---
+
+It's Christmas!
+
+Well, it's Christmas soon, and to celebrate, we have released a new running
+badge to adorn those runners who have managed to run on Christmas day.
+
+(We'd really like to give extra special kudos to those volunteers giving up their
+Christmas morning, but until the parkrun website lists the dates of each volunteer
+role, unfortunately we aren't able to do so.)
+
+
+Additionally, we have added the 'All Weather Runner' badge, contributed by
+[Russell Boyatt](https://github.com/rboyatt) - this badge celebrates those parkrunners
+who have kept up their attendence come rain or shime and have run at least once
+in every calendar month (they don't have to be in the same year).
+
+![Run on Christmas Day (25th December)]({{ site.baseurl }}/img/badges/runner-christmas-day.png)![All Weather Runner - Run in each month of the year (not necessarily in the same year)]({{ site.baseurl }}/img/badges/runner-all-weather-runner.png)
+{: style="text-align: center;"}
+
+Happy parkrunning!
+
+If you have already installed the extension it should update soon - typically we
+have found it takes a few days for Chrome and Firefox to auto-update, but it should
+do so eventually. If you haven't yet joined the fun you can get it from one of
+the links below. :
+
+[![Running Challenges in the Chrome Web Store]({{ site.baseurl }}/img/ChromeWebStore_BadgeWBorder_v2_206x58.png "Running Challenges in the Chrome Web Store")]({{ site.data.webstore.webstore-running-challenges-link }})[![Running Challenges in the Firefox Add-ons Web Store]({{ site.baseurl }}/img/firefox_web_store-172x60.png "Running Challenges in the Firefox Add-ons Web Store")]({{ site.data.webstore.firefox-running-challenges-link }})
+{: style="text-align: center;"}


### PR DESCRIPTION
  - Bump version string
  - Add release blogpost
  - Add website script to build and run locally
  - Remove categories from the website link to make much shorter URLs