### PR TITLE
Introducing the v-index

### DIFF
--- a/browser-extensions/common/js/lib/challenges.js
+++ b/browser-extensions/common/js/lib/challenges.js
@@ -355,6 +355,29 @@ function generate_stat_p_index(parkrun_results) {
   }
 }
 
+// The number of volunteer roles which have been performed at least _v_ times.
+// E.g. If you have volunteered in 4 different roles at least 4 times, your v-index
+// is 4.
+function generate_stat_v_index(volunteer_data) {
+  var v_index = 0
+  var descending_tally = Object.keys(volunteer_data).sort(function(a, b) {
+    return volunteer_data[b] - volunteer_data[a]
+  })
+  // Iterate through the roles, and as long as the number of times we have
+  // volunteered in the role is greater than the index value, increment the
+  // v-index
+  descending_tally.forEach(function(role_name, index) {
+    if (volunteer_data[role_name] > index) {
+      v_index += 1
+    }
+  })
+  return {
+    "display_name": "v-index",
+    "help": "The number of volunteer roles which have been performed at least v times. E.g. If you have volunteered in 4 different roles at least 4 times, your v-index is 4.",
+    "value": v_index
+  }
+}
+
 // The maximum contiguous series of parkrun event numbers you have attended
 // (at any event), starting at 1.
 function generate_stat_wilson_index(parkrun_results) {
@@ -757,6 +780,7 @@ function generate_stats(data) {
   if (data.info.has_volunteer_data) {
     stats['total_volunteer_roles'] = generate_stat_total_volunteer_roles(data.volunteer_data)
     stats['total_distinct_volunteer_roles'] = generate_stat_total_distinct_volunteer_roles(data.volunteer_data)
+    stats['v_index'] = generate_stat_v_index(data.volunteer_data)
   }
 
   return stats

--- a/website/_data/stats.yml
+++ b/website/_data/stats.yml
@@ -137,3 +137,12 @@ stats:
       How many of the different volunteering roles have been completed.
       Note - this can include multiple roles per week e.g. if you were a marshal,
       did course setup, and close-down, that adds 3 to this stat.
+
+  - shortname: paj/v-index
+    name: v-index
+    description: >-
+      The number of volunteer roles which have been performed at least v times.
+      E.g. If you have volunteered in 4 different roles at least 4 times, your
+      v-index is 4. This stat was created by [Mel Erbacher](https://www.parkrun.com.au/results/athleteeventresultshistory/?athleteNumber=384152&eventNumber=0)
+      on [episode 158](https://parkrunadventurers.podbean.com/e/episode-158-v-index/)
+      of the [parkrun Adventurers podcast](https://www.facebook.com/parkrunadventurers/).


### PR DESCRIPTION
#### Context

![image](https://user-images.githubusercontent.com/39911/59154206-a0503900-8ab0-11e9-8eaa-0c107e2af929.png)

Listening to the [parkrun adventurers](https://www.facebook.com/parkrunadventurers/) podcast [Episode 158](https://parkrunadventurers.podbean.com/e/episode-158-v-index/) where Mel introduced the concept of a "v-index": the number of volunteer roles you've performed at least _v_ times. I thought, "how hard can it be?"

#### Change

A riff on the p-index code.

#### Considerations

I'm not a Javascript programmer and this is my first attempt at coding for a browser extension so this might not be the best implementation.

#### Confirmation

I've tested this in Firefox and Chrome. [Mel has a v-index of 7](https://www.parkrun.com.au/results/athleteeventresultshistory/?athleteNumber=384152&eventNumber=0) (Run Director x 92, Timekeeper x 25, Photographer x 14, Barcode Scanning x 10, Tail Walker x 10, Other x 8, Volunteer Co-ordinator x 7) and [I have a v-index of 5](https://www.parkrun.com.au/results/athleteeventresultshistory/?athleteNumber=384152&eventNumber=0) (Run Director x 31, Photographer x 17, Pre-event Setup x 16, Barcode Scanning x 5, Marshal x 5).

<img width="217" alt="image" src="https://user-images.githubusercontent.com/39911/59154250-59af0e80-8ab1-11e9-83a2-3e8b1f40eb68.png">

[Me in Chrome]

<img width="207" alt="results | parkrun Australia 2019-06-09 12-03-37" src="https://user-images.githubusercontent.com/39911/59154267-cf1adf00-8ab1-11e9-8e2e-818c477b337f.png">


[Mel in Firefox]