### PR TITLE
Post release tasks v0.7.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,21 +104,21 @@ roles, and they will need adding in in a few places:
 1. When everything has been tested and merged into master, tag master with the
 version in `build/version.sh`. This will trigger a Travis build to push the built
 zips to a Github release.
-```
-git tag v0.7.5
-git push origin v0.7.5
-```
+    ```
+    git tag v0.7.5
+    git push origin v0.7.5
+    ```
 1. Watch the [Travis build](https://travis-ci.org/fraz3alpha/running-challenges) run.
 1. Head over to the [releases](https://github.com/fraz3alpha/running-challenges/releases)
 tab in Github and find the release for the [version you tagged](https://github.com/fraz3alpha/running-challenges/releases/tag/v0.7.5).
 1. Edit the release with any information that you may want to include in release notes, or perhaps form the basis of the blog post.
 1. Download the zips and test them in Chrome and Firefox to check they load and don't give any errors - load a couple of profiles and if you have added some new countries or badges, check those.
-  - In Firefox, go to `about:debugging` and load a temporary add-on
-  - In Chrome, go to `chrome://extensions` and load an unpacked extension
+    - In Firefox, go to `about:debugging` and load a temporary add-on
+    - In Chrome, go to `chrome://extensions` and load an unpacked extension
 1. Go to the [Chrome webstore](https://chrome.google.com/webstore/developer/dashboard) and upload the new version.
 1. Go to the [Mozilla Add-ons site](https://addons.mozilla.org/en-GB/firefox/) and upload the new version. Make sure to check that it is compatible with Android, this is unchecked by default. Add the release notes when asked.
 1. Complete the release by creating a PR to include:
-  - Prepare for the next release by updating the version string in `build/version.sh`
-    to the next appropriate number (this can always be changed later)
-  - Add a blog post in `website/_posts` - just copy the last release and change
-    the pertinent bits.
+    - Prepare for the next release by updating the version string in `build/version.sh`
+      to the next appropriate number (this can always be changed later)
+    - Add a blog post in `website/_posts` - just copy the last release and change
+      the pertinent bits.

--- a/README.md
+++ b/README.md
@@ -117,5 +117,8 @@ tab in Github and find the release for the [version you tagged](https://github.c
   - In Chrome, go to `chrome://extensions` and load an unpacked extension
 1. Go to the [Chrome webstore](https://chrome.google.com/webstore/developer/dashboard) and upload the new version.
 1. Go to the [Mozilla Add-ons site](https://addons.mozilla.org/en-GB/firefox/) and upload the new version. Make sure to check that it is compatible with Android, this is unchecked by default. Add the release notes when asked.
-1. Prepare for the next release by updating the version string in `build/version.sh` to the next appropriate number (this can always be changed later), and commit it to master.
-1. Add a blog post in `website/_posts` - just copy the last release and change the pertinent bits.
+1. Complete the release by creating a PR to include:
+  - Prepare for the next release by updating the version string in `build/version.sh`
+    to the next appropriate number (this can always be changed later)
+  - Add a blog post in `website/_posts` - just copy the last release and change
+    the pertinent bits.

--- a/build/version.sh
+++ b/build/version.sh
@@ -1,4 +1,4 @@
-export VERSION=0.7.6
+export VERSION=0.7.7
 # Strip any 'v' characters from the version string, as exist in the git tag
 export EXTENSION_BUILD_VERSION=`echo ${EXTENSION_BUILD_VERSION:-$VERSION} | sed -e s/v//`
 # Default the build id variable to zero if not set - Travis should set this to

--- a/website/_posts/2019-06-09-v0.7.6-released.markdown
+++ b/website/_posts/2019-06-09-v0.7.6-released.markdown
@@ -1,0 +1,45 @@
+---
+layout: post
+title:  "Version 0.7.6 Released"
+date:   2019-06-09 22:00:00 +0100
+categories:
+  - chrome-extension
+  - firefox-addon
+  - release
+---
+
+Full Ponty challenge extended and the addition of a new stat - the v-index!
+
+## Full Ponty challenge
+
+Back in April a new parkrun started in Bala, Wales, and it was officially named
+as [Pont y Bala](https://www.parkrun.org.uk/pontybala/). This update includes the
+Bala parkrun in the Full Ponty challenge that so many people love :)
+
+## v-index stat
+
+The p-index generated a lot of interest - and quite a bit of confusion, when it
+was first introduced, so the v-index doubles the fun :) Instead of having to do
+some parkrun tourist to improve your p-index, the v-index focuses on different
+volunteering roles.
+
+This was first mentioned by Mel in [Episode 158](https://parkrunadventurers.podbean.com/e/episode-158-v-index/)
+of the [parkrun adventurers](https://www.facebook.com/parkrunadventurers/) podcast -
+check it out!
+
+It's all very simple, it is the number of different volunteering roles, v, that
+you have done at least v times each.
+
+Many thanks to [Pete Johns](https://github.com/johnsyweb) from Melbourne who
+wrote the initial code to add this based on the p-index, and created a pull-request
+in GitHub so we could included it - Nice one!
+
+## How do I get all of this great stuff?
+
+If you have already installed the extension it should update soon - typically we
+have found it takes a few days for Chrome and Firefox to auto-update, but it should
+do so eventually.  If you haven't yet joined the fun you can get it from one of
+the links below. :
+
+[![Running Challenges in the Chrome Web Store]({{ site.baseurl }}/img/ChromeWebStore_BadgeWBorder_v2_206x58.png "Running Challenges in the Chrome Web Store")]({{ site.data.webstore.webstore-running-challenges-link }})[![Running Challenges in the Firefox Add-ons Web Store]({{ site.baseurl }}/img/firefox_web_store-172x60.png "Running Challenges in the Firefox Add-ons Web Store")]({{ site.data.webstore.firefox-running-challenges-link }})
+{: style="text-align: center;"}

--- a/website/_posts/2019-06-09-v0.7.6-released.markdown
+++ b/website/_posts/2019-06-09-v0.7.6-released.markdown
@@ -20,7 +20,7 @@ Bala parkrun in the Full Ponty challenge that so many people love :)
 
 The p-index generated a lot of interest - and quite a bit of confusion, when it
 was first introduced, so the v-index doubles the fun :) Instead of having to do
-some parkrun tourist to improve your p-index, the v-index focuses on different
+some parkrun tourism to improve your p-index, the v-index focuses on different
 volunteering roles.
 
 This was first mentioned by Mel in [Episode 158](https://parkrunadventurers.podbean.com/e/episode-158-v-index/)


### PR DESCRIPTION
  - Add release blogpost
  - Bump version number for the next development cycle
  - Updates to the release doc