### PR TITLE
Introducing the Volunteer Quotient

### DIFF
--- a/browser-extensions/common/js/lib/challenges.js
+++ b/browser-extensions/common/js/lib/challenges.js
@@ -405,6 +405,34 @@ function generate_stat_v_index(volunteer_data) {
   }
 }
 
+// A percentage showing how often you volunteer. Someone who never participates
+// at an event is on infinity, somebody who's volunteered 20 times and
+// participated 100 times would be on 20%, and someone who never volunteers
+// would be on 0%.
+function generate_stat_volunteer_quotient(parkrun_results, volunteer_data) {
+  var volunteer_quotient = "&infin;"
+
+  var total_volunteer_roles = 0
+  $.each(volunteer_data, function(role, count) {
+    total_volunteer_roles += count
+  })
+
+  var total_runs = 0
+  parkrun_results.forEach(function(parkrun_event) {
+    total_runs += 1
+  })
+
+  if (total_runs > 0) {
+    volunteer_quotient = (100 * total_volunteer_roles / total_runs).toFixed(2) + "%"
+  }
+
+  return {
+    "display_name": "Volunteer Quotient",
+    "help": "A percentage showing how often you volunteer. Someone who never participates at an event is on infinity, somebody who's volunteered 20 times and participated 100 times would be on 20%, and someone who never volunteers would be on 0%.",
+    "value": volunteer_quotient
+  }
+}
+
 // The maximum contiguous series of parkrun event numbers you have attended
 // (at any event), starting at 1.
 function generate_stat_wilson_index(parkrun_results) {
@@ -808,6 +836,7 @@ function generate_stats(data) {
     stats['total_volunteer_roles'] = generate_stat_total_volunteer_roles(data.volunteer_data)
     stats['total_distinct_volunteer_roles'] = generate_stat_total_distinct_volunteer_roles(data.volunteer_data)
     stats['v_index'] = generate_stat_v_index(data.volunteer_data)
+    stats['volunteer_quotient'] = generate_stat_volunteer_quotient(data.parkrun_results, data.volunteer_data)
   }
 
   return stats

--- a/website/_data/stats.yml
+++ b/website/_data/stats.yml
@@ -146,3 +146,11 @@ stats:
       v-index is 4. This stat was created by [Mel Erbacher](https://www.parkrun.com.au/results/athleteeventresultshistory/?athleteNumber=384152&eventNumber=0)
       on [episode 158](https://parkrunadventurers.podbean.com/e/episode-158-v-index/)
       of the [parkrun Adventurers podcast](https://www.facebook.com/parkrunadventurers/).
+
+  - shortname: volunteer_quotient
+    name: Volunteer Quotient
+    description: >-
+      A percentage showing how often you volunteer. Someone who never
+      participates at an event is on infinity, somebody who's volunteered 20
+      times and participated 100 times would be on 20%, and someone who never
+      volunteers would be on 0%.


### PR DESCRIPTION
#### Context

#169 seems to have been [well received](https://www.facebook.com/groups/parkruntourismAU/permalink/2232221143565029/) and I'd love to add more to recognise the folks who make parkrun happen... the volunteers.

#### Change

Add a Volunteer Quotient statistic, based on the the _Total volunteer roles_ and _Total number of parkruns_ stats and the _Tourist Quotient_ implementation. Nothing fancy. Oh and I remembered to update the website this time.

#### Considerations

While I think this is an interesting stat, only [one commentator](https://www.facebook.com/groups/parkruntourismAU/permalink/2232221143565029/?comment_id=2233911820062628) has asked for this. Feel free to accept or reject as you see fit.

#### Confirmation

##### Some people prefer not to volunteer...
![Screenshot_2019-06-18 results parkrun Australia](https://user-images.githubusercontent.com/39911/59674731-3ef23d80-9207-11e9-9251-4d3057e087f7.png)

##### Some people like to participate more than volunteer...
![Screenshot_2019-06-18 results parkrun Australia(1)](https://user-images.githubusercontent.com/39911/59674732-3ef23d80-9207-11e9-81f8-f29bd84b50f8.png)

##### Some people like to volunteer more than participate...
![Screenshot_2019-06-18 results parkrun Australia(3)](https://user-images.githubusercontent.com/39911/59674734-3f8ad400-9207-11e9-9887-4babb90c17b2.png)

##### Some people prefer not to participate...
![Screenshot_2019-06-18 results parkrun Australia(2)](https://user-images.githubusercontent.com/39911/59674733-3ef23d80-9207-11e9-96c2-e55e0205dae8.png)

##### Website update...
![image](https://user-images.githubusercontent.com/39911/59674852-6cd78200-9207-11e9-82d0-66e802e8fbad.png)
