### PR TITLE
Fix Dockerfile to build extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 
 FROM node:lts-jessie
 
+RUN npm -g config set user root
 RUN npm install --global web-ext
 
 RUN mkdir /rc

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker build -t rc:latest .
 Then run the Docker container:
 
 ```
-docker run -v `pwd`:/rc rc:latest
+docker run --rm -v `pwd`:/rc rc:latest
 ```
 
 ## Browser Extensions: non-Docker build


### PR DESCRIPTION
Updated Dockerfile to run npm command as root (otherwise it fails). As described in https://medium.com/@aguidrevitch/when-installation-of-global-package-using-npm-inside-docker-fails-b551b5dda389
Updated Docker run command in README to remove container on exit.