### PR TITLE
Updates to script to test website locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/.DS_Store
 **/*~
+.jekyll-cache/

--- a/README.md
+++ b/README.md
@@ -11,26 +11,31 @@ alphabet), 'Tourist' (running 20 or more different parkruns), and many more.
 
 ## Website
 
-The /website folder containers a Jekyll based website
+The `/website` folder containers a Jekyll-based website. You can build and serve the website
+locally for testing by running a bash script (Linux and Mac only).
 
-It can be built with:
+1. Download the git submodule which contains additional Running Challenges data (the build fails without this). From the root of the project:
+  
+    `cd running-challenges-data`
+  
+    `git submodule update --init --recursive`
+  
+    `cd ..`
+1. From the root of the project, run the bash script:
 
-```
-docker run --rm --name jekyll \
--v `pwd`:/srv/jekyll \
--v `pwd`/vendor/bundle:/usr/local/bundle \
-jekyll/jekyll jekyll build
-```
+    `./build/website/build-local-and-run.sh`
 
-or served for local testing with:
+    If you have other Jekyll sites running in Docker containers, you can specify a port mapping
+  when you run the script (eg to expose port 4002 instead of the default 4000):
 
-```
-docker run --rm --name jekyll \
--p 4000:4000 \
--v `pwd`:/srv/jekyll \
--v `pwd`/vendor/bundle:/usr/local/bundle \
-jekyll/jekyll jekyll serve
-```
+    `JEKYLL_PORT=4002 ./build/website/build-local-and-run.sh`
+1. In a web browser, open the locally-hosted website:
+
+    `http://localhost:4002/`
+
+    Any changes you make to pages of the website should automatically get picked up when you refresh (F5) the page.
+1. To stop the local website running, press CTRL+C in the terminal.
+
 
 ## Browser Extensions: Docker build
 

--- a/build/website/build-local-and-run.sh
+++ b/build/website/build-local-and-run.sh
@@ -2,6 +2,9 @@
 
 # This script pushing the built copy of the this site to a staging repository
 
+JEKYLL_PORT=${JEKYLL_PORT:-4000}
+
+
 # Enable exit on failure
 set -e
 
@@ -58,7 +61,7 @@ SITE_DIR=_site
 rm -rf ${SITE_DIR} && mkdir ${SITE_DIR}
 
 docker run --rm --name jekyll \
--p 4000:4000 \
+-p ${JEKYLL_PORT}:4000 \
 -v `pwd`:/srv/jekyll \
 -v `pwd`/vendor/bundle:/usr/local/bundle \
 jekyll/jekyll jekyll serve


### PR DESCRIPTION
- Update build-local-and-run.sh script so that you can specify a custom Jekyll port when running the script  (eg if you already have a Jekyll container running on 4000).
- Update README with instructions on how to run the script instead of running the basic Docker run command which no longer works because common image directories (for extensions and website) are in root of the project.
- Added cache folder to gitignore - it was generated when running the script.