### PR TITLE
WIP: Record Breaker badge & persist challenge visibility

### DIFF
--- a/browser-extensions/common/js/content-scripts/content-script-athleteeventresultshistory.js
+++ b/browser-extensions/common/js/content-scripts/content-script-athleteeventresultshistory.js
@@ -421,7 +421,7 @@ parsed_results_data = parse_results_table()
 set_progress_message("Parsed Results")
 
 set_progress_message("Loading saved data")
-browser.storage.local.get(["home_parkrun_info", "athlete_number"]).then((items) => {
+browser.storage.local.get(["home_parkrun_info", "athlete_number", "challengeMetadata"]).then((items) => {
   set_progress_message("Loaded saved data")
   loaded_user_data = items
   // console.log("Here is the stored items, fetched with a promise:")

--- a/build/version.sh
+++ b/build/version.sh
@@ -1,4 +1,4 @@
-export VERSION=0.7.7
+export VERSION=0.7.8
 # Strip any 'v' characters from the version string, as exist in the git tag
 export EXTENSION_BUILD_VERSION=`echo ${EXTENSION_BUILD_VERSION:-$VERSION} | sed -e s/v//`
 # Default the build id variable to zero if not set - Travis should set this to

--- a/website/_data/badges.yml
+++ b/website/_data/badges.yml
@@ -58,9 +58,9 @@ runner:
     name: Groundhog Day
     description: Finish with the same time at the same parkrun location on two consecutive parkruns.
 
-  # - shortname: regionnaire
-  #   name: Regionnaire
-  #   description: Run all the parkrun locations in a geographical region.
+  - shortname: record-breaker
+    name: Record Breaker
+    description: Run all the parkrun events within 33km, 45km, and 78km of your home parkrun.
 
   - shortname: all-weather-runner
     name: All Weather Runner


### PR DESCRIPTION
  - Add a badge to cover running all the events within 33km, 45km,
    & 78km of your home parkrun. This gives people something local to 
    aim for now that the regions have gone.
  - Challenges have been able to be collapsed by clicking on the icon
    for some time, although I suspect this is not very well known. This
    change persists the knowledge of whether it is hidden to the user
    data area, so that it will be retained when you reload the page.
    This will allow people to hide the ones they don't care much about,
    but still have them instantly available to show if they want