### PR TITLE
Added Closest Average parkrun stat

### DIFF
--- a/website/_data/stats.yml
+++ b/website/_data/stats.yml
@@ -114,6 +114,14 @@ stats:
       where you will be on average - probably in the sea!
 
 
+  - shortname: closest_average_parkrun
+    name: Closest parkrun to average
+    description: >-
+      The parkrun that is closest to the average latitude/longitude of all your
+      parkrun attendances. This will most likely be your home parkrun - but
+      could be somewhere entirely different if you do a lot of tourism!
+
+
   - shortname: furthest_travelled
     name: Furthest travelled
     description: >-


### PR DESCRIPTION
Adds the closest average parkrun as a stat, and breaks out the average parkrun location into a separate function so it doesn't need to be calculated twice.

Implements enhancement #173.