### PR TITLE
Bundle the obsessive badges into a single table

### DIFF
--- a/browser-extensions/common/js/lib/challenges.js
+++ b/browser-extensions/common/js/lib/challenges.js
@@ -202,9 +202,8 @@ function generate_running_challenge_data(data) {
     challenge_data.push(challenge_obsessive(data, 
       {
         "shortname": "obsessive-gold",
-        "badge_icon": "parkrun-obsessive-gold",
         "name": "parkrun Obsessive",
-        "help": "Run at 30+ (bronze), 40+ (silver), or 50+(gold) parkruns in a calendar year",
+        "help": "Run at 30+ (bronze), 40+ (silver), or 50+(gold) parkruns in a calendar year.",
         "stages": [
           {
             "count": 30,

--- a/browser-extensions/common/js/lib/challenges.js
+++ b/browser-extensions/common/js/lib/challenges.js
@@ -199,21 +199,31 @@ function generate_running_challenge_data(data) {
         {"month": 11},
       ],
       "help": "Run in each month of the year."}))
-    challenge_data.push(challenge_in_a_year(data, {
-      "shortname": "obsessive-bronze",
-      "name": "Bronze Level Obsessive",
-      "data": 30,
-      "help": "Run 30+ parkruns in one calendar year."}))
-    challenge_data.push(challenge_in_a_year(data, {
-      "shortname": "obsessive-silver",
-      "name": "Silver Level Obsessive",
-      "data": 40,
-      "help": "Run 40+ parkruns in one calendar year."}))
-    challenge_data.push(challenge_in_a_year(data, {
-      "shortname": "obsessive-gold",
-      "name": "Gold Level Obsessive",
-      "data": 50,
-      "help": "Run 50+ parkruns in one calendar year."}))
+    challenge_data.push(challenge_obsessive(data, 
+      {
+        "shortname": "obsessive-gold",
+        "badge_icon": "parkrun-obsessive-gold",
+        "name": "parkrun Obsessive",
+        "help": "Run at 30+ (bronze), 40+ (silver), or 50+(gold) parkruns in a calendar year",
+        "stages": [
+          {
+            "count": 30,
+            "name": "Bronze",
+            "badge_icon": "runner-obsessive-bronze"
+          },
+          {
+            "count": 40,
+            "name": "Silver",
+            "badge_icon": "runner-obsessive-silver"
+          },
+          {
+            "count": 50,
+            "name": "Gold",
+            "badge_icon": "runner-obsessive-gold"
+          }
+        ]
+      }))
+
   }
 
   // if (data.parkrun_results && data.geo_data) {
@@ -1970,14 +1980,16 @@ function challenge_groundhog_day(data, params) {
     return update_data_object(o)
 }
 
-function challenge_in_a_year(data, params) {
+function challenge_obsessive(data, params) {
 
     var parkrun_results = data.parkrun_results
-    var count = params.data
+    var stages = params.stages
 
     var o = create_data_object(params, "runner")
     o.subparts = ["1"]
     o.summary_text = "0"
+
+    var badgesAwarded = []
 
     by_year = {}
 
@@ -1993,32 +2005,99 @@ function challenge_in_a_year(data, params) {
 
     })
 
-    Object.keys(by_year).sort().forEach(function (year) {
-        if (by_year[year].length >= count) {
-            o.subparts_detail.push({
-                "name": year,
-                "date": year,
-                "info": by_year[year].length,
-                "subpart": count+"+"
-            })
-            o.subparts_completed_count += 1
-            if (!o.complete) {
-                o.complete = true
-                o.completed_on = year
-            }
-        }
+    // We now have an object showing us how many parkruns were attended in each year.
+    // Until such a time as volunteering can be allocated in this way, this just means 
+    // running and getting a result.
+
+    console.log(by_year)
+
+    var subBadgesAvailable = []
+
+    $.each(stages, function(index, obsessiveMilestone) {
+      subBadgesAvailable.push({
+        "awarded": false
+      })
     })
 
-    if (o.subparts_detail.length == 0) {
+    // Now lets look at each year for which we have data, and see if the different milestones 
+    // have been reached.
+    Object.keys(by_year).sort().forEach(function (year) {
+      var currentBadge = undefined
+      $.each(stages, function(index, obsessiveMilestone) {
+        if (by_year[year].length >= obsessiveMilestone.count) {
+          currentBadge = {
+            "index": index,
+            "name": obsessiveMilestone.name,
+            "count": obsessiveMilestone.count,
+            "badge_icon": obsessiveMilestone.badge_icon
+          }
+        }
+      })
+      if (currentBadge !== undefined) {
+        // Award a badge for this year
         o.subparts_detail.push({
-            "subpart": count+"+",
-            "info": "-"
+          "name": year,
+          "date": year,
+          "info": by_year[year].length,
+          "subpart": currentBadge.name+" ("+currentBadge.count+"+)",
+          "badge": currentBadge
         })
-    }
+        // Ensure that we add the badge at the top
+        subBadgesAvailable[currentBadge.index].awarded = true
+      }
+
+    })
 
     // Change the summary to indicate number of times completed
-    if (o.subparts_completed_count > 0) {
-        o.summary_text = "x"+o.subparts_completed_count
+    if (o.subparts_detail.length > 0) {
+      o.summary_text = "x"+o.subparts_detail.length
+    }
+
+    // Award the badges to be displayed at the top
+    $.each(subBadgesAvailable, function(index, subBadge) {
+      if (subBadge.awarded == true) {
+        badgesAwarded.push({
+          "name": stages[index].name,
+          "badge_icon": stages[index].badge_icon
+        })
+      }
+    })
+
+    o.badgesAwarded = badgesAwarded
+
+
+    // Display the badges above what the parkrunner has, so they can see
+    // what is still to come. i.e. if they have nothing, show all 3 badges,
+    // if they have bronze, show silver+gold, have silver, show gold, if 
+    // they already have gold, they then don't need hints and that'll do :)
+
+    // Find the highest ones they have.
+    var maxBadgeAwarded = -1
+    $.each(subBadgesAvailable, function(index, subBadge) {
+      if (subBadge.awarded) {
+        maxBadgeAwarded = index
+      }
+    })
+    console.log("parkrunner has achieved max obsessive level of " + maxBadgeAwarded)
+
+    // Add the badge for any higher badges than the ones they have
+    $.each(stages, function(index, obsessiveMilestone) {
+      if (index > maxBadgeAwarded) {
+        o.subparts_detail.push({
+          // "subpart": count+"+",
+          "badge": {
+            "name": obsessiveMilestone.name,
+            "badge_icon": obsessiveMilestone.badge_icon
+          },
+          "subpart": obsessiveMilestone.name+" ("+obsessiveMilestone.count+"+)",
+          "name": "-"
+        })
+      }
+    })
+
+    // If they have been awarded the maximum badge, then give them a tick
+    if (maxBadgeAwarded == stages.length-1) {
+      o.complete = true
     }
 
     // Return an object representing this challenge


### PR DESCRIPTION
  - Similar to #226 , use up less of the page for showing the same data, this 
    time for obsessive badges.
  - All the obsessive badges are now in a single challenge. You will
    now get the highest available badge per year, rather than achieving
    all of the ones you qualify for (i.e. if you get a gold badge one year,
    you will no no-longer get the bronze and silver badges for that year
    as well). After all, this is how it works in sport - the person
    coming first doesn't get the medals for second and third too :)
  - If you don't have any badges, or haven't yet achieved the highest
    badge (gold) it will display placeholders to show what you could win
    in the future for the ones you haven't surpassed yet.