### PR TITLE
Add nearest parkrun to average parkrun location stat

### DIFF
--- a/browser-extensions/common/js/lib/challenges.js
+++ b/browser-extensions/common/js/lib/challenges.js
@@ -636,6 +636,7 @@ function generate_stat_total_countries_visited(parkrun_results, geo_data) {
   }
 }
 
+// Calculate average lat/lon of all parkruns completed
 function generate_stat_average_parkrun_location(parkrun_results, geo_data) {
   var lat_sum = 0
   var lon_sum = 0
@@ -672,7 +673,7 @@ function generate_stat_average_parkrun_location(parkrun_results, geo_data) {
 }
 
 
-// calculate average parkrun location
+// Calculate average parkrun location
 function calculate_average_parkrun_location(parkrun_results, geo_data) {
 var lat_sum = 0
   var lon_sum = 0
@@ -703,6 +704,24 @@ var lat_sum = 0
   }
 }
 
+// What's the URL of the parkrun's page?
+function get_parkrun_page_url(data, parkrun_name) {
+  parkrun_page_url = undefined
+  if (data.info.has_geo_data) {
+    if (parkrun_name in data.geo_data.data.events) {
+      parkrun_shortname = data.geo_data.data.events[parkrun_name].shortname
+      country_name = data.geo_data.data.events[parkrun_name].country_name
+      if (country_name in data.geo_data.data.countries) {
+        domain_url = data.geo_data.data.countries[country_name].url
+        parkrun_page_url = "https://" + domain_url + "/" + parkrun_shortname
+      }
+    }
+  }
+  return parkrun_page_url
+}
+
+
+
 // Which is the closest parkrun to your average parkrun location?
 function generate_stat_average_parkrun_event(parkrun_results, geo_data) {
   // Calculate average parkrun for user
@@ -722,12 +741,21 @@ function generate_stat_average_parkrun_event(parkrun_results, geo_data) {
       average_parkrun_event_distance = distance
     }
   })
+
+  var url_link = get_parkrun_page_url(data, average_parkrun_event_name)
+  console.log(url_link)
   return {
     "display_name": "Average parkrun event",
     "help": "The nearest parkrun event to your average parkrun location.",
-    "value": average_parkrun_event_name
+    "value": average_parkrun_event_name,
+    "url": url_link
   }
 }
+
+
+
+
+
 
 
 // Furthest parkrun you have run away from your home parkrun
@@ -853,7 +881,7 @@ function generate_stats(data) {
     stats['total_distance_travelled'] = generate_stat_total_distance_travelled(data.parkrun_results, data.geo_data)
     stats['total_countries_visited'] = generate_stat_total_countries_visited(data.parkrun_results, data.geo_data)
     stats['average_parkrun_location'] = generate_stat_average_parkrun_location(data.parkrun_results, data.geo_data)
-    stats['average_parkrun_event'] = generate_stat_average_parkrun_event(data.parkrun_results, data.geo_data) // Laura
+    stats['average_parkrun_event'] = generate_stat_average_parkrun_event(data.parkrun_results, data.geo_data)
   }
 
   // Stats that need the user data available, and we are on their page (i.e. has

--- a/browser-extensions/common/js/lib/challenges.js
+++ b/browser-extensions/common/js/lib/challenges.js
@@ -704,7 +704,7 @@ var lat_sum = 0
   }
 }
 
-// What's the URL of the parkrun's page?
+// What's the URL of the parkrun's webpage?
 function get_parkrun_page_url(data, parkrun_name) {
   parkrun_page_url = undefined
   if (data.info.has_geo_data) {
@@ -720,18 +720,13 @@ function get_parkrun_page_url(data, parkrun_name) {
   return parkrun_page_url
 }
 
-
-
 // Which is the closest parkrun to your average parkrun location?
 function generate_stat_average_parkrun_event(parkrun_results, geo_data) {
   // Calculate average parkrun for user
   var average_parkrun_location = calculate_average_parkrun_location(parkrun_results, geo_data)
-
   var average_parkrun_event_name = ''
   var average_parkrun_event_distance = undefined
-  
   // For each parkrun event, get the event's information, which includes its lon and lat.
-  // (for each key-value pair in the ...events hash array, run the function passing in the key and value as parameters of that function.)
   $.each(geo_data.data.events, function(event_name, event_location_info) {
     // For each parkrun event, calculate the 3D distance between the event and the user's average parkrun location
     var distance = calculate_great_circle_distance(event_location_info, average_parkrun_location)
@@ -743,7 +738,7 @@ function generate_stat_average_parkrun_event(parkrun_results, geo_data) {
   })
 
   var url_link = get_parkrun_page_url(data, average_parkrun_event_name)
-  console.log(url_link)
+  
   return {
     "display_name": "Average parkrun event",
     "help": "The nearest parkrun event to your average parkrun location.",
@@ -751,12 +746,6 @@ function generate_stat_average_parkrun_event(parkrun_results, geo_data) {
     "url": url_link
   }
 }
-
-
-
-
-
-
 
 // Furthest parkrun you have run away from your home parkrun
 function generate_stat_furthest_travelled(parkrun_results, geo_data, home_parkrun) {
@@ -783,10 +772,13 @@ function generate_stat_furthest_travelled(parkrun_results, geo_data, home_parkru
     furthest_travelled.display_name = furthest_travelled.parkrun_event.name + ", " + furthest_travelled.parkrun_event.country_name
   }
 
+  var url_link = get_parkrun_page_url(data, furthest_travelled.parkrun_event.name)
+
   return {
     "display_name": "Furthest travelled",
     "help": "The furthest away parkrun you have been to (calculated from your home parkrun).",
-    "value": furthest_travelled.display_name + ", "+ furthest_travelled.distance + "km"
+    "value": furthest_travelled.display_name + ", "+ furthest_travelled.distance + "km",
+    "url": url_link
   }
 }
 
@@ -823,10 +815,13 @@ function generate_stat_nearest_event_not_done_yet(parkrun_results, geo_data, hom
     value = nendy.name + ", " + nendy.country_name+ " - " + Math.round(event_distances[nendy_name]) + "km away"
   }
 
+  var url_link = get_parkrun_page_url(data, nendy.name)
+
   return {
     "display_name": "Nearest event not done yet (NENDY)",
     "help": "The nearest parkrun event to your home parkrun that you have not done yet.",
-    "value": value
+    "value": value,
+    "url": url_link
   }
 }
 

--- a/website/_data/stats.yml
+++ b/website/_data/stats.yml
@@ -115,7 +115,7 @@ stats:
 
   - shortname: average_parkrun_event
     name: Average parkrun event
-     description: >-
+    description: >-
       The closest parkrun event to your average parkrun location.
       In case you want to go run it.
 

--- a/website/_data/stats.yml
+++ b/website/_data/stats.yml
@@ -113,11 +113,11 @@ stats:
       towards your home parkrun. If, however, you visit all over the world, who knows
       where you will be on average - probably in the sea!
 
-    - shortname: average_parkrun_event
-      name: Average parkrun event
-      description: >-
-        The closest parkrun event to your average parkrun location.
-        In case you want to go run it.
+  - shortname: average_parkrun_event
+    name: Average parkrun event
+     description: >-
+      The closest parkrun event to your average parkrun location.
+      In case you want to go run it.
 
   - shortname: furthest_travelled
     name: Furthest travelled

--- a/website/_data/stats.yml
+++ b/website/_data/stats.yml
@@ -113,6 +113,11 @@ stats:
       towards your home parkrun. If, however, you visit all over the world, who knows
       where you will be on average - probably in the sea!
 
+    - shortname: average_parkrun_event
+      name: Average parkrun event
+      description: >-
+        The closest parkrun event to your average parkrun location.
+        In case you want to go run it.
 
   - shortname: furthest_travelled
     name: Furthest travelled


### PR DESCRIPTION
- Added row to the stats table ("Average parkrun event") to display the nearest parkrun event to the "Average parkrun lat/lon location" (already in stats table) #173 
- Made the name of the average parkrun event into a clickable link to take you to the homepage for that parkrun event.
- Made the "Furthest travelled" and "Nearest event not done yet (NENDY)" parkrun names into clickable links too so that it's consistent and not confusing to have some parkrun names clickable and some not.
- Added to release blog post.