### PR TITLE
show progress when no ton badges awarded yet

### DIFF
--- a/browser-extensions/common/js/lib/challenges.js
+++ b/browser-extensions/common/js/lib/challenges.js
@@ -1756,7 +1756,7 @@ function challenge_stopwatch_bingo(data, params) {
     return update_data_object(o)
 }
 
-// Complete 100 or 200 parkruns at the same venue
+// Complete 100 or 200 parkruns at the same venue - tons of runs challenge
 function challenge_single_parkrun_count(data, params) {
 
   var parkrun_results = data.parkrun_results
@@ -1770,7 +1770,7 @@ function challenge_single_parkrun_count(data, params) {
 
   parkruns_completed = {}
   max_count = 0
-  max_parkrun = null
+  max_parkrun = undefined
 
   parkrun_results.forEach(function (parkrun_event) {
     if (!(parkrun_event.name in parkruns_completed)) {
@@ -1782,7 +1782,19 @@ function challenge_single_parkrun_count(data, params) {
       }
     }
     parkruns_completed[parkrun_event.name].count += 1
+
+    // Identify which parkrun event is most attended 
+    // so that we can print progress towards the badge
+    // if haven't already got one
+    if (parkruns_completed[parkrun_event.name].count > max_count) {
+      //console.log(parkruns_completed[parkrun_event.name])
+      max_parkrun = Object.create(parkruns_completed[parkrun_event.name])
+      max_count = parkruns_completed[parkrun_event.name].count
+      //console.log("max_count: "+max_count+" "+JSON.stringify(parkruns_completed[parkrun_event.name]))
+    }
+    //console.log(max_parkrun)
   })
+
 
   // Now we have an object showing how many times each
   // parkrun has been completed
@@ -1794,12 +1806,14 @@ function challenge_single_parkrun_count(data, params) {
       "awarded": false
     })
   })
-console.log("parkruns completed: " + parkruns_completed)
+  console.log("parkruns completed: " + parkruns_completed)
   // Now look at which completed parkruns have reached
   // the 'ton' milestones
   Object.keys(parkruns_completed).sort().forEach(function (name) {
     var currentBadge = undefined
-    $.each(stages, function(index, tonMilestone) {
+    for(var index = 0; index < stages.length; index++){
+      var tonMilestone = stages[index]
+    //$.each(stages, function(index, tonMilestone) {
       if (parkruns_completed[name].count >= tonMilestone.count) {
         currentBadge = {
           "index": index,
@@ -1808,7 +1822,7 @@ console.log("parkruns completed: " + parkruns_completed)
           "badge_icon": tonMilestone.badge_icon
         }
       }
-    })
+    }
       if (currentBadge !== undefined) {
         // Award a badge for this parkrun event
         o.subparts_detail.push({
@@ -1837,8 +1851,17 @@ console.log("parkruns completed: " + parkruns_completed)
         })
       }
     })
-
     o.badgesAwarded = badgesAwarded
+
+    if (max_parkrun !== undefined){
+      if (badgesAwarded.length == 0) {
+        o.subparts_detail.push({
+          "name": max_parkrun.name,
+          "info": max_count,
+          "subpart": "Highest so far"
+        })
+      }
+    }
 
     // Display the badges above what the parkrunner has, so they can see
     // what is still to come. i.e. if they have nothing, show all badges,
@@ -1853,17 +1876,6 @@ console.log("parkruns completed: " + parkruns_completed)
       }
     })
     console.log("parkrunner has achieved max ton level of " + maxBadgeAwarded)
-
-/* 
-    // Identify which parkrun event is most attended 
-    // so that we can print progress towards the badge
-    // if haven't already got one
-    if (parkruns_completed[parkrun_event.name].count > max_count) {
-      max_parkrun = Object.create(parkruns_completed[parkrun_event.name])
-      max_count = parkruns_completed[parkrun_event.name].count
-  }
- */
-
 
     // Add the badge for any higher badges than the ones they have
     $.each(stages, function(index, tonMilestone) {


### PR DESCRIPTION
Adds row at the top of the Tons of runs table to show progress towards the 100 badge (ie how many times highest parkrun run).

![image](https://user-images.githubusercontent.com/3322532/74608254-7804e980-50d7-11ea-8e14-c957fb23acc1.png)

Tested on
- [someone with both badges](https://www.parkrun.org.uk/results/athleteeventresultshistory/?athleteNumber=26084&eventNumber=0#double-ton) - shows two badge rows
- [someone without either badges](https://www.parkrun.org.uk/results/athleteeventresultshistory/?athleteNumber=2363530&eventNumber=0) - shows additional row at the top of the table indicating which parkrun is currently highest and how many times run
- [someone with no runs](https://www.parkrun.org.uk/results/athleteeventresultshistory/?athleteNumber=236353000&eventNumber=0#all-weather-runner) - blank rows for the two badges and no additional row showing progress (ie it doesn't blow up)