### PR TITLE
Tidy up bundling process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,17 @@ before_install:
   - gem install bundler
 
 script:
-   # Run the tests against the Javascript libraries we have writte
-   - bash -c "cd ./browser-extensions/common/js && npm run test-with-coverage"
    # Only build the staging website if the github token is available, which means
    # that it will only happen for PRs from our own repo, not forks.
    - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then if [ "$RUNNING_CHALLENGES_GITHUB_TOKEN" != "" ]; then bash ./build/website/build-staging.sh; fi; fi'
    - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./build/website/build.sh; fi'
    - './build/extension-chrome/build.sh'
    - './build/extension-firefox/build.sh'
+   # Moving the test until after the build to start with, so that I can defer having to work out how
+   # not to bundle the coverage data into the extension zip files.
+   # Perhaps we should actually be testing the bundled code, rather than that in the repo, not sure.
+   # Run the tests against the Javascript libraries we have written
+   - bash -c "cd ./browser-extensions/common/js && npm run test-with-coverage"
 
 # branch whitelist.
 # For GitHub Pages - if we push code to master the built code goes to gh-pages

--- a/build/extension-chrome/build.sh
+++ b/build/extension-chrome/build.sh
@@ -66,4 +66,4 @@ web-ext lint
 web-ext build
 
 # Print the size of the built extension
-ls -l "${TMP_BUILD_DIR}/web-ext-artifacts/running_challenges-*.zip"
+ls -l web-ext-artifacts/running_challenges-*.zip

--- a/build/extension-chrome/build.sh
+++ b/build/extension-chrome/build.sh
@@ -64,3 +64,6 @@ cd ${TMP_BUILD_DIR}
 # zip -r extension.zip js/ html/ images/ css/ manifest.json
 web-ext lint
 web-ext build
+
+# Print the size of the built extension
+ls -l "${TMP_BUILD_DIR}/web-ext-artifacts/running_challenges-*.zip"

--- a/build/extension-firefox/build.sh
+++ b/build/extension-firefox/build.sh
@@ -70,4 +70,4 @@ web-ext lint
 web-ext build
 
 # Print the size of the built extension
-ls -l "${TMP_BUILD_DIR}/web-ext-artifacts/running_challenges-*.zip"
+ls -l web-ext-artifacts/running_challenges-*.zip

--- a/build/extension-firefox/build.sh
+++ b/build/extension-firefox/build.sh
@@ -68,3 +68,6 @@ for i in patches/firefox/*.patch; do patch -p0 --directory "${TMP_BUILD_DIR}" < 
 cd ${TMP_BUILD_DIR}
 web-ext lint
 web-ext build
+
+# Print the size of the built extension
+ls -l "${TMP_BUILD_DIR}/web-ext-artifacts/running_challenges-*.zip"


### PR DESCRIPTION
  - Build was previously putting node dependencies and coverage data into the built zip files