### PR TITLE
Remove activeTab permission, which we don't need

### DIFF
--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -136,7 +136,6 @@
       "/css/*"
   ],
   "permissions": [
-    "activeTab",
     "storage",
     "https://www.parkrun.org.uk/",
     "https://wiki.parkrun.com/"

--- a/browser-extensions/firefox/manifest.json
+++ b/browser-extensions/firefox/manifest.json
@@ -139,7 +139,6 @@
       "/css/*"
   ],
   "permissions": [
-    "activeTab",
     "storage",
     "https://www.parkrun.org.uk/",
     "https://wiki.parkrun.com/"


### PR DESCRIPTION
  - The Chrome extension webstore now asks for justification for each
    permission, and I couldn't justify the activeTab permission because
    I didn't know how we used it. Turned out, that we don't, and so I
    removed it from both the Firefox and Chrome manifests
- https://developer.chrome.com/extensions/activeTab