### PR TITLE
Rename v1.1.0 blog post to v1.1.1 to match the latest fix

### DIFF
--- a/website/_posts/2020-02-16-v1.1.1-name-badge-tons-netherlands.markdown
+++ b/website/_posts/2020-02-16-v1.1.1-name-badge-tons-netherlands.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title:  "Name Badge challenge, tons of runs, parkrun Netherlands, and bug fixes (v1.1.0)"
+title:  "Name Badge challenge, tons of runs, parkrun Netherlands, and bug fixes (v1.1.1)"
 date:   2020-02-16 19:00:00 +0000
 categories:
   - chrome-extension
   - firefox-addon
   - release
 ---
-Loads of stuff in v1.1.0, both new and bugs fixes. Take a look...
+Loads of stuff in v1.1.1, both new and bugs fixes. Take a look...
 
 ## New!
 


### PR DESCRIPTION
This will make the announcement less confusing