### PR TITLE
Handle volunteer data on non org.uk sites 

### DIFF
--- a/browser-extensions/common/js/content-scripts/content-script-athleteeventresultshistory.js
+++ b/browser-extensions/common/js/content-scripts/content-script-athleteeventresultshistory.js
@@ -38,7 +38,7 @@ function parse_volunteer_table(result) {
      // "Volunteer Summary"
      var results_table = $(this)
      parent = $(this).parent()
-     $("h1:contains('Volunteer Summary')", parent).each(function (index) {
+     $("h1#volunteer-summary", parent).each(function (index) {
          completed_volunteer_roles = {}
          $("tbody>tr", results_table).each(function (role_index) {
              table_cells = $("td", this)

--- a/browser-extensions/common/js/content-scripts/content-script-athleteeventresultshistory.js
+++ b/browser-extensions/common/js/content-scripts/content-script-athleteeventresultshistory.js
@@ -541,7 +541,7 @@ browser.storage.local.get(["home_parkrun_info", "athlete_number"]).then((items) 
     // domain into our CSP, which is a bit annoying, but would maybe
     // turn out to be more efficient for the user in a country far away
     // from the UK (depending on where parkrun host these servers)
-    url: "https://www.parkrun.org.uk/results/athleteresultshistory/?athleteNumber="+get_athlete_id(),
+    url: location.protocol + '//' + location.host + '/results/athleteresultshistory/?athleteNumber='+get_athlete_id(),
     dataType: 'html'})
 }).then((results) => {
   set_progress_message("Loaded volunteer data")

--- a/browser-extensions/common/js/content-scripts/content-script-athleteeventresultshistory.js
+++ b/browser-extensions/common/js/content-scripts/content-script-athleteeventresultshistory.js
@@ -541,7 +541,7 @@ browser.storage.local.get(["home_parkrun_info", "athlete_number"]).then((items) 
     // domain into our CSP, which is a bit annoying, but would maybe
     // turn out to be more efficient for the user in a country far away
     // from the UK (depending on where parkrun host these servers)
-    url: location.protocol + '//' + location.host + '/results/athleteresultshistory/?athleteNumber='+get_athlete_id(),
+    url: 'https://' + location.host + '/results/athleteresultshistory/?athleteNumber='+get_athlete_id(),
     dataType: 'html'})
 }).then((results) => {
   set_progress_message("Loaded volunteer data")


### PR DESCRIPTION
Resolves #277 for non org.uk sites - uses local parkrun site for volunteer data and (as we're now looking at non-English language sites) selects volunteer table using id attribute rather than 'Volunteer summary'.

I don't think any further changes to policies are required to make this work.