### PR TITLE
Switch from Travis CI to Github Actions

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -53,4 +53,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           jekyll_src: 'website'
           jekyll_env: production
-          build_only: true # Delegate pushing of the built site the subsquent step so that we can direct which repo it goes to
+          # For now, lets make it push to the main repository, and see if that works,
+          # we can dev dev builds working later
+          target_branch: gh-pages
+          # build_only: true # Delegate pushing of the built site the subsquent step so that we can direct which repo it goes to

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -1,0 +1,56 @@
+name: Website Builder
+
+# Run this workflow every time a new commit pushed to your repository,
+# and periodically, to pick up any other updates that may have occurred - 
+# e.g. in the data repository
+on: 
+  push:
+    branches:
+      - main
+  schedule:
+    # Run daily at 1pm
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 13 * * *'
+
+jobs:
+  # Set the job key. The key is displayed as the job name
+  # when a job name is not provided
+  website-builder:
+    # Name the Job
+    name: Build the website from this repository
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Get the submodules as well
+      - name: Checkout submodules
+        uses: textbook/git-checkout-submodule-action@master
+
+      # Use GitHub Actions' cache to shorten build times and decrease load on servers
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      # Prepare the website directory
+      - name: Copy dependencies to Website directory
+        run: |
+          echo `pwd`
+          bash ./build/website/copy-assets.sh
+        shell: bash
+
+      # Standard usage of the plugin as described on https://jekyllrb.com/docs/continuous-integration/github-actions/
+      # on 2021-01-31
+      # https://github.com/marketplace/actions/jekyll-actions
+      - name: Build the Jekyll site
+        uses:  helaili/jekyll-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          jekyll_src: 'website'
+          jekyll_env: production
+          build_only: true # Delegate pushing of the built site the subsquent step so that we can direct which repo it goes to

--- a/build/website/copy-assets.sh
+++ b/build/website/copy-assets.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Enable exit on failure
+set -e
+
+echo "Copying shared resources to the website folder"
+
+echo "Copying badges to website img/badges directory"
+mkdir -p website/img/badges
+cp -r images/badges/256x256/*.png website/img/badges/
+
+echo "Copying flags to website img/flags directory"
+mkdir -p website/img/flags
+cp -r images/flags/twemoji/png/*.png website/img/flags/
+
+echo "Copying logos to website img/logo directory"
+mkdir -p website/img/logo
+cp -r images/logo/*.png website/img/logo/
+
+echo "Copying screenshots to website img/screenshots directory"
+mkdir -p website/img/screenshots
+cp -r images/screenshots/*.png website/img/screenshots/
+
+echo "Copying third party Javascript libraries into the assets directory"
+# Copy the required third party libraries from the top level shared project dir
+mkdir -p website/assets/js/lib/third-party/
+cp -r js/lib/third-party/jquery website/assets/js/lib/third-party/
+cp -r js/lib/third-party/leaflet website/assets/js/lib/third-party/
+cp -r js/lib/third-party/leaflet-canvasicon website/assets/js/lib/third-party/
+cp -r js/lib/third-party/leaflet-extramarkers website/assets/js/lib/third-party/
+cp -r js/lib/third-party/leaflet-fullscreen website/assets/js/lib/third-party/
+cp -r js/lib/third-party/leaflet-markercluster website/assets/js/lib/third-party/
+cp -r js/lib/third-party/leaflet-piechart website/assets/js/lib/third-party/
+
+echo "Copying third party CSS libraries into the assets directory"
+# Copy the required third party libraries from the top level shared project dir
+mkdir -p website/assets/css/third-party/
+cp -r css/third-party/leaflet website/assets/css/third-party/
+cp -r css/third-party/leaflet-extramarkers website/assets/css/third-party/
+cp -r css/third-party/leaflet-fullscreen website/assets/css/third-party/
+cp -r css/third-party/leaflet-markercluster website/assets/css/third-party/


### PR DESCRIPTION
Travis CI is becoming increasingly slow and as of 2021-05-16 says:
> Please be aware travis-ci.org will be shutting down in several weeks, with all accounts migrating to travis-ci.com. Please stay tuned here for more information.
It said this back in January too, which is when I first started looking into Github Actions, but life got in the way.

So, lets move over what I achieved over in my testing repo, and see if we can gradually get this repo to build everything with Actions.

I'm going to disable Travis, and  merge this to the master branch to get the ball rolling. We need to have something in the main branch for it to do anything, and having it half-broken will force me to fix it
