### PR TITLE
Update github action build script to use node-12

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Configure node v10
+      - name: Configure node v12
         uses: actions/setup-node@v2
         with:
-          node-version: '10'
+          node-version: '12'
 
       - name: Install test framework dependencies
         run: npm install
@@ -46,10 +46,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Configure node v10
+      - name: Configure node v12
         uses: actions/setup-node@v2
         with:
-          node-version: '10'
+          node-version: '12'
 
       - name: Install web-ext tooling
         run: npm install -g web-ext


### PR DESCRIPTION
Something in the Github Actions build is complaining about not supporting node 10, so I'm going to try going up to 12.
It happens when we try and run the `web-ext` command to build the extension.

```
Error: yargs supports a minimum Node.js version of 12. Read our version support policy: https://github.com/yargs/yargs#supported-nodejs-versions
    at Object.<anonymous> (/opt/hostedtoolcache/node/10.24.1/x64/lib/node_modules/web-ext/node_modules/addons-linter/node_modules/yargs/build/index.cjs:1:55294)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/opt/hostedtoolcache/node/10.24.1/x64/lib/node_modules/web-ext/node_modules/addons-linter/node_modules/yargs/index.cjs:5:30)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
```