### PR TITLE
Remove scheduled website build

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -13,10 +13,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    # Run daily at 1pm
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '0 13 * * *'
   workflow_dispatch:
     # Allow it to be run manually - useful for testing?
 


### PR DESCRIPTION
  - By having a scheduled build we appear to be at risk of the workflow being disabled (if there are no new commits), and that means it doesn't run for any reason, even PRs that come along later, so lets just turn it off