### PR TITLE
Fixed bug with AthleteID being shown in "Name Badge" challenge.

### DIFF
--- a/browser-extensions/common/js/lib/challenges.js
+++ b/browser-extensions/common/js/lib/challenges.js
@@ -1649,6 +1649,7 @@ function challenge_name_badge(data, params) {
   o.subparts_count = 0
 
   if (pageAthleteInfo !== undefined && pageAthleteInfo.name !== undefined) {
+    pageAthleteInfo.name = pageAthleteInfo.name.replace(/ *\([^)]*\) */g, "").trim();
     for(var i=0; i< pageAthleteInfo.name.length; i++) {
       var letter = pageAthleteInfo.name[i].toLowerCase()
       // console.log(letter)


### PR DESCRIPTION
Just removing everything between parentheses and trimming the whitespace, fixes it and doesn't look to cause any other issues.