### PR TITLE
Added alternate name for "Warm Up Leader"

### DIFF
--- a/browser-extensions/common/js/lib/challenges.js
+++ b/browser-extensions/common/js/lib/challenges.js
@@ -32,7 +32,7 @@ volunteer_roles_map = [
     {"shortname": "token-sorting", "name": "Token Sorting"},
     {"shortname": "report-writer", "name": "Report Writer"},
     {"shortname": "other", "name": "Other"},
-    {"shortname": "warm-up-leader", "name": "Warm Up Leader", "matching-roles": ["Warm Up Leader (junior events only)"]},
+    {"shortname": "warm-up-leader", "name": "Warm Up Leader", "matching-roles": ["Warm Up Leader (junior events only)", "Warm Up Leader"]},
 ]
 
 function group_volunteer_data(volunteer_data) {


### PR DESCRIPTION
parkrun look to have removed " (junior events only)" from the description of "Warm Up Leader". Not seen any announcements about warm-ups being extended to non-junior events - so possibly just a tweak to the name. Put it in as an alternative name, just in case they swap it back.