### PR TITLE
Switch to Google Analytics 4

### DIFF
--- a/website/_config.yml
+++ b/website/_config.yml
@@ -75,8 +75,8 @@ permalink: /:year/:month/:day/:title:output_ext
 # cd running-challenges/blog
 # docker run --rm --name jekyll -it -p 4000:4000 -v `pwd`:/srv/jekyll -v `pwd`/vendor/bundle:/usr/local/bundle jekyll/jekyll jekyll serve
 
-google_analytics: "UA-115520338-2"
-google_analytics_staging: "UA-115520338-3"
+google_analytics: "G-40C839RGVJ"
+google_analytics_staging: "G-WGW2CKNMMG"
 
 exclude: 
   - vendor

--- a/website/_includes/google-analytics-staging.html
+++ b/website/_includes/google-analytics-staging.html
@@ -1,6 +1,6 @@
+<!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_staging }}"></script>
 <script>
-  window['ga-disable-{{ site.google_analytics_staging }}'] = window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1";
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());

--- a/website/_includes/google-analytics-staging.html
+++ b/website/_includes/google-analytics-staging.html
@@ -1,4 +1,4 @@
-<!-- Google tag (gtag.js) -->
+<!-- Google tag (gtag.js) for the staging website -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_staging }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/website/_includes/google-analytics.html
+++ b/website/_includes/google-analytics.html
@@ -1,6 +1,6 @@
+<!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
 <script>
-  window['ga-disable-{{ site.google_analytics }}'] = window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1";
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());

--- a/website/_includes/google-analytics.html
+++ b/website/_includes/google-analytics.html
@@ -1,4 +1,4 @@
-<!-- Google tag (gtag.js) -->
+<!-- Google tag (gtag.js) for the production website -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
This doesn't work on staging, as it should, because it doesn't override the `_includes/head.html` file for some reason, I keep getting the default, but the updated values should mean the data is sent to the right place for GA4