### PR TITLE
Fix JavaScript error when viewing a parkrunner with no runs recorded.

### DIFF
--- a/browser-extensions/common/js/content-scripts/content-script-parkrunner.js
+++ b/browser-extensions/common/js/content-scripts/content-script-parkrunner.js
@@ -209,7 +209,9 @@ function parse_results_table() {
     return a.date_obj - b.date_obj
   })
 
-  console.log("Sorted parkruns, first: " + parkruns_completed_sorted[0].date + " last: "+ parkruns_completed_sorted[parkruns_completed_sorted.length - 1].date)
+  if (parkruns_completed_sorted.length > 0) {
+    console.log("Sorted parkruns, first: " + parkruns_completed_sorted[0].date + " last: "+ parkruns_completed_sorted[parkruns_completed_sorted.length - 1].date)
+  }
 
   return parkruns_completed_sorted
 }


### PR DESCRIPTION
Currently the extension hits a JavaScript error if the parkrunner being viewed hasn't recorded any runs. The error is being thrown from within a `console.log` statement: this PR fixes the issue by skipping this `console.log` statement if no runs have been recorded.