### PR TITLE
Alternative origins for Record Breaker

### DIFF
--- a/browser-extensions/common/js/lib/challenges.js
+++ b/browser-extensions/common/js/lib/challenges.js
@@ -296,10 +296,11 @@ function challenge_record_breaker(data, params) {
   geoData = data.geo_data
   user_data = data.user_data
 
-  const reference_parkrun_name = user_data?.home_parkrun_info?.name ??
-    calculate_average_parkrun_event_name(parkrunResults, geoData) ??
-    'Bushy Park';
-  var reference_parkrun = geoData.data.events[reference_parkrun_name]
+  const reference_parkrun_name = (is_our_page(data) && data.info.has_home_parkrun) ?
+      user_data?.home_parkrun_info?.name :
+      calculate_average_parkrun_event_name(parkrunResults, geoData) ?? 'Bushy Park';
+
+  const reference_parkrun = geoData.data.events[reference_parkrun_name]
 
   var o = create_data_object(params, "runner")
   o.has_map = true

--- a/browser-extensions/common/js/lib/challenges.js
+++ b/browser-extensions/common/js/lib/challenges.js
@@ -296,7 +296,9 @@ function challenge_record_breaker(data, params) {
   geoData = data.geo_data
   user_data = data.user_data
 
-  var reference_parkrun_name = calculate_average_parkrun_event_name(parkrunResults, geoData)
+  const reference_parkrun_name = user_data?.home_parkrun_info?.name ??
+    calculate_average_parkrun_event_name(parkrunResults, geoData) ??
+    'Bushy Park';
   var reference_parkrun = geoData.data.events[reference_parkrun_name]
 
   var o = create_data_object(params, "runner")


### PR DESCRIPTION
#### Context

My first overseas parkrun skewed this challenge so much it's entirely unattainable unless I move state. This is likely true for many other parkrunners.

#398 shows that the challenge is broken for those who've yet to complete a 5k.

#### Change

- If we're on our own page, and we've set a home parkrun, use this as the centre for the Record Breaker challenge.
- If we're not on our own page, or we've not set a home parkrun, use the "average parkrun" as the origin for the Record Breaker challenge. For many, this will be their home run.
- If there's no calculable Record Breaker challenge, use the original origin: Bushy Park!
 
#### Confirmation

Incoming!

#### Considerations

I'm not strongly tied to this implementation and won't be offended if it's rejected.
