### PR TITLE
Extra fixes for manifest v3

### DIFF
--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -54,7 +54,6 @@
         "js/lib/i18n.js",
         "js/lib/challenges.js",
         "js/lib/challenges_ui.js",
-        "js/lib/cache.js",
         "js/content-scripts/content-script-parkrunner.js"
       ],
       "css": [

--- a/browser-extensions/chrome/manifest.json
+++ b/browser-extensions/chrome/manifest.json
@@ -158,7 +158,7 @@
         "/html/*.html",
         "/css/*"
       ],
-      "use_dynamic_url": true
+      "use_dynamic_url": false
     }
   ],
   "permissions": [

--- a/browser-extensions/common/js/tests/ui-test/package-lock.json
+++ b/browser-extensions/common/js/tests/ui-test/package-lock.json
@@ -1,53 +1,49 @@
 {
-  "name": "playwright-testing",
+  "name": "running-challenges-chrome-ui-testing",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "playwright-testing",
+      "name": "running-challenges-chrome-ui-testing",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.32.2"
+        "@playwright/test": "^1.50.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.32.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.2.tgz",
-      "integrity": "sha512-nhaTSDpEdTTttdkDE8Z6K3icuG1DVRxrl98Qq0Lfc63SS9a2sjc9+x8ezysh7MzCKz6Y+nArml3/mmt+gqRmQQ==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
+      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "*",
-        "playwright-core": "1.32.2"
+        "playwright": "1.50.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.50.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
-    },
-    "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.32.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.2.tgz",
-      "integrity": "sha512-zD7aonO+07kOTthsrCR3YCVnDcqSHIJpdFUtZEMOb6//1Rc7/6mZDRdw+nlzcQiQltOOsiqI3rrSyn/SlyjnJQ==",
-      "dev": true,
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
-      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -62,40 +58,18 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
-    }
-  },
-  "dependencies": {
-    "@playwright/test": {
-      "version": "1.32.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.2.tgz",
-      "integrity": "sha512-nhaTSDpEdTTttdkDE8Z6K3icuG1DVRxrl98Qq0Lfc63SS9a2sjc9+x8ezysh7MzCKz6Y+nArml3/mmt+gqRmQQ==",
+    },
+    "node_modules/playwright-core": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
       "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "fsevents": "2.3.2",
-        "playwright-core": "1.32.2"
+      "bin": {
+        "playwright-core": "cli.js"
       },
-      "dependencies": {
-        "playwright-core": {
-          "version": "1.32.2",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.2.tgz",
-          "integrity": "sha512-zD7aonO+07kOTthsrCR3YCVnDcqSHIJpdFUtZEMOb6//1Rc7/6mZDRdw+nlzcQiQltOOsiqI3rrSyn/SlyjnJQ==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=18"
       }
-    },
-    "@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
-      "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     }
   }
 }

--- a/browser-extensions/common/js/tests/ui-test/package.json
+++ b/browser-extensions/common/js/tests/ui-test/package.json
@@ -16,6 +16,6 @@
   },
   "homepage": "https://github.com/fraz3alpha/playwright-testing#readme",
   "devDependencies": {
-    "@playwright/test": "^1.32.2"
+    "@playwright/test": "^1.50.1"
   }
 }

--- a/browser-extensions/common/js/tests/ui-test/supporting-data/etc-hosts.txt
+++ b/browser-extensions/common/js/tests/ui-test/supporting-data/etc-hosts.txt
@@ -12,6 +12,7 @@
 127.0.0.1 www.parkrun.fr
 127.0.0.1 www.parkrun.ie
 127.0.0.1 www.parkrun.it
+127.0.0.1 www.parkrun.lt
 127.0.0.1 www.parkrun.jp
 127.0.0.1 www.parkrun.my
 127.0.0.1 www.parkrun.no

--- a/browser-extensions/firefox/manifest.json
+++ b/browser-extensions/firefox/manifest.json
@@ -161,8 +161,7 @@
         "/images/flags/*.png",
         "/html/*.html",
         "/css/*"
-      ],
-      "use_dynamic_url": true
+      ]
     }
   ],
   "permissions": [
@@ -172,7 +171,6 @@
     "page": "html/options.html"
   },
   "background": {
-    "service_worker": "js/background.js",
     "scripts": ["js/background.js"]
   }
 }


### PR DESCRIPTION
- Remove options that were causing (non-terminal) plugin load errors on Firefox
- Fix image loading permission problems for images referenced in CSS files
- Remove duplicate include line for `cache.js`