### PR TITLE
Fix text elements in SVG

### DIFF
--- a/browser-extensions/common/js/lib/challenges_ui.js
+++ b/browser-extensions/common/js/lib/challenges_ui.js
@@ -396,7 +396,7 @@ function createVoronoiMapPrototype() {
           item_text.setAttribute("font-size", zoomScaleOptions.eventNameTextSize+"px")
           item_text.setAttribute("font-weight", "bold")
           item_text.setAttribute("dominant-baseline", "hanging") // Hang the text below
-          item_text.innerText = filtered_points[index].name
+          item_text.textContent = filtered_points[index].name
         }
 
         // Create a shape to represent the voronoi area associated with this parkrun event


### PR DESCRIPTION
parkrun names weren't appearing, that's because of the switch to the new tag creation mechanism